### PR TITLE
Added Highlight Text Span for "=="

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -141,6 +141,7 @@ dependencies {
     implementation "io.noties.markwon:editor:$markwon_version"
     implementation "io.noties.markwon:linkify:$markwon_version"
     implementation "io.noties.markwon:ext-strikethrough:$markwon_version"
+    implementation "io.noties.markwon:simple-ext:$markwon_version"
     implementation "io.noties.markwon:ext-tables:$markwon_version"
     implementation "io.noties.markwon:ext-tasklist:$markwon_version"
     implementation "me.saket:better-link-movement-method:2.2.0"

--- a/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
+++ b/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
@@ -1,6 +1,8 @@
 package org.qosp.notes.di
 
 import android.content.Context
+import android.graphics.Color
+import android.text.style.BackgroundColorSpan
 import android.text.util.Linkify
 import dagger.Module
 import dagger.Provides
@@ -13,6 +15,7 @@ import io.noties.markwon.LinkResolverDef
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.SoftBreakAddsNewLinePlugin
+import io.noties.markwon.SpanFactory
 import io.noties.markwon.editor.MarkwonEditor
 import io.noties.markwon.editor.handler.EmphasisEditHandler
 import io.noties.markwon.editor.handler.StrongEmphasisEditHandler
@@ -21,6 +24,7 @@ import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.ext.tasklist.TaskListPlugin
 import io.noties.markwon.linkify.LinkifyPlugin
 import io.noties.markwon.movement.MovementMethodPlugin
+import io.noties.markwon.simple.ext.SimpleExtPlugin
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 import org.qosp.notes.R
 import org.qosp.notes.data.sync.core.SyncManager
@@ -49,6 +53,13 @@ object MarkwonModule {
                 override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
                     builder.linkResolver(LinkResolverDef())
                 }
+            })
+            .usePlugin(SimpleExtPlugin.create { plugin: SimpleExtPlugin ->
+                plugin
+                    .addExtension(
+                        2,
+                        '=',
+                        SpanFactory { _, _ -> BackgroundColorSpan(Color.RED) })
             })
             .usePlugin(CoilImagesPlugin.create(context, syncManager))
             .apply {

--- a/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
+++ b/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
@@ -1,9 +1,9 @@
 package org.qosp.notes.di
 
 import android.content.Context
-import android.graphics.Color
 import android.text.style.BackgroundColorSpan
 import android.text.util.Linkify
+import android.util.TypedValue
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -59,7 +59,12 @@ object MarkwonModule {
                     .addExtension(
                         2,
                         '=',
-                        SpanFactory { _, _ -> BackgroundColorSpan(Color.RED) })
+                        SpanFactory { _, _ ->
+                            val typedValue = TypedValue()
+                            context.theme.resolveAttribute(R.attr.colorNoteTextHighlight, typedValue, true)
+                            val color = typedValue.data;
+                            return@SpanFactory BackgroundColorSpan(color)
+                        })
             })
             .usePlugin(CoilImagesPlugin.create(context, syncManager))
             .apply {

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -38,6 +38,8 @@
         <item name="colorNoteOrange">#65452A</item>
         <item name="colorNoteYellow">#68643A</item>
 
+        <item name="colorNoteTextHighlight">#96FFFF00</item>
+
         <item name="popupTheme">@style/Widget.Custom.PopupMenu</item>
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
     </style>

--- a/app/src/main/res/values/attr.xml
+++ b/app/src/main/res/values/attr.xml
@@ -20,6 +20,7 @@
     <!-- Notes -->
     <attr name="colorNoteText" format="color"/>
     <attr name="colorNoteIndicator" format="color"/>
+    <attr name="colorNoteTextHighlight" format="color"/>
     <attr name="colorAttachmentIndicator" format="color"/>
 
     <attr name="colorNoteDefault" format="color"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,6 +37,8 @@
         <item name="colorNoteOrange">#FFAB91</item>
         <item name="colorNoteYellow">#FFF59D</item>
 
+        <item name="colorNoteTextHighlight">#96FFFF00</item>
+
         <item name="popupTheme">@style/Widget.Custom.PopupMenu</item>
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
     </style>


### PR DESCRIPTION
Using the 'simple-ext' package was the easiest way I could implement the Highlight option. The other way would be to write a totally new plugin

Just followed the Docs for Markwon https://noties.io/Markwon/docs/v4/simple-ext/
Honestly I have no idea what I am doing with Kotlin, maybe someone can help improve this..? 

For #24 

![image](https://user-images.githubusercontent.com/8670239/204550453-caa29970-16e2-4a90-8bd7-d0feddf31913.png)
