### PR TITLE
Move floating editor button to top menu (#83)

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -669,6 +669,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         findItem(R.id.action_pin_note)?.apply {
             setIcon(if (note.isPinned) R.drawable.ic_pin_filled else R.drawable.ic_pin)
+            setTitle(if (note.isPinned) R.string.action_unpin else R.string.action_pin)
             isVisible = !note.isDeleted
         }
 

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -311,11 +311,6 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                 text?.insert(selectionStart, markdown)
             }
         }
-
-        binding.fabChangeMode.setOnClickListener {
-            updateEditMode(!model.inEditMode)
-            if (model.inEditMode) requestFocusForFields(true) else view.hideKeyboard()
-        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -369,6 +364,12 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
                 R.id.action_pin_note -> {
                     activityModel.pinNotes(note)
+                }
+
+                R.id.action_change_mode -> {
+                    updateEditMode(!model.inEditMode)
+                    if (model.inEditMode) requestFocusForFields(true) else view?.hideKeyboard()
+                    setupMenuItems(note, note.reminders.isNotEmpty())
                 }
 
                 R.id.action_hide_note -> {
@@ -654,6 +655,16 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             title =
                 if (note.isList) getString(R.string.action_convert_to_note) else getString(R.string.action_convert_to_list)
             isVisible = !note.isDeleted
+        }
+
+        findItem(R.id.action_change_mode)?.apply {
+            setIcon(if (model.inEditMode) R.drawable.ic_show else R.drawable.ic_pencil)
+
+            val noteHasEmptyContent = note?.title?.isBlank() == true || when (note?.isList) {
+                true -> note.taskList.isEmpty()
+                else -> note?.content?.isBlank() == true
+            }
+            isVisible = !note.isDeleted && !noteHasEmptyContent
         }
 
         findItem(R.id.action_pin_note)?.apply {
@@ -1082,16 +1093,6 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         textViewContentPreview.isVisible = !model.inEditMode && !isList
         editTextContent.isVisible = model.inEditMode && !isList
 
-        val shouldDisplayFAB = !isNoteDeleted && !noteHasEmptyContent
-        when {
-            fabChangeMode.isVisible == shouldDisplayFAB -> { /* FAB is already like it should be, no reason to animate */
-            }
-
-            fabChangeMode.isVisible && !shouldDisplayFAB -> fabChangeMode.hide()
-            else -> fabChangeMode.show()
-        }
-
-        fabChangeMode.setImageResource(if (model.inEditMode) R.drawable.ic_show else R.drawable.ic_pencil)
         setMarkdownToolbarVisibility(note)
     }
 

--- a/app/src/main/res/layout/fragment_editor.xml
+++ b/app/src/main/res/layout/fragment_editor.xml
@@ -147,16 +147,6 @@
 
     </androidx.core.widget.NestedScrollView>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_change_mode"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:src="@drawable/ic_pencil"
-            app:layout_constraintBottom_toTopOf="@id/container_bottom_toolbar"
-            app:layout_constraintEnd_toEndOf="parent"
-            style="@style/Widget.Custom.FloatingActionButton"/>
-
     <LinearLayout
             android:id="@+id/container_bottom_toolbar"
             android:layout_width="match_parent"

--- a/app/src/main/res/menu/editor_top.xml
+++ b/app/src/main/res/menu/editor_top.xml
@@ -3,6 +3,13 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <!-- Change editor between view and edit mode -->
+    <item
+        android:id="@+id/action_change_mode"
+        android:icon="@drawable/ic_show"
+        android:title="@string/action_change_mode"
+        android:visible="false"
+        app:showAsAction="ifRoom"/>
     <item
             android:id="@+id/action_pin_note"
             android:icon="@drawable/ic_pin"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="action_hide">Hide</string>
     <string name="action_show">Show</string>
     <string name="action_archive">Archive</string>
+    <string name="action_change_mode">Edit/View mode</string>
     <string name="action_pin">Pin</string>
     <string name="action_unpin">Unpin</string>
     <string name="action_restore">Restore</string>


### PR DESCRIPTION
This PR gets rid of the floating editor button and moves it to the top menu, to not cover the text.
closes #83 

Review, thoughts etc. appreciated (I'm quite new to Android development). :)

Demo:
![#83](https://user-images.githubusercontent.com/7658194/225778328-b3bef63b-ae3d-4d1c-a36b-239cf3245e49.gif)


