### PR TITLE
Fix #107 (display read/edit mode FAB also if note has empty title)

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -1051,7 +1051,8 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     /** Gives the focus to the editor fields if they are empty */
     private fun requestFocusForFields(forceFocus: Boolean = false) = with(binding) {
-        if (editTextTitle.text.isNullOrEmpty()) {
+        // Don't set focus to title if already auto-set to 'Untitled' (probably user doesn't want to set title)
+        if (editTextTitle.text.isNullOrEmpty() && textViewTitlePreview.text.toString() != getString(R.string.indicator_untitled).toString()) {
             editTextTitle.requestFocusAndKeyboard()
         } else {
             if (editTextContent.text.isNullOrEmpty() || forceFocus) {
@@ -1062,10 +1063,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     private fun updateEditMode(inEditMode: Boolean = model.inEditMode, note: Note? = data.note) = with(binding) {
         // If the note is empty the fragment should open in edit mode by default
-        val noteHasEmptyContent = note?.title?.isBlank() == true || when (note?.isList) {
-            true -> note.taskList.isEmpty()
-            else -> note?.content?.isBlank() == true
-        }
+        val noteHasEmptyContent = note?.content?.isBlank() == true || (note?.isList == true && note.taskList.isEmpty())
 
         model.inEditMode = (inEditMode || noteHasEmptyContent) && !isNoteDeleted
 


### PR DESCRIPTION
Demo:
![FAB_no title1](https://user-images.githubusercontent.com/7658194/229881698-0aca67d9-8ec9-4f23-bf01-9270e26e4ca8.gif)

Additionally there's a slight change in behaviour when user re-edits content of an untitled note.
Previously it would set focus to the title, but it seems to make more sense if focus is set to content in this case imo (seen at end of the gif).
But this can be reverted if wanted. :)
