### PR TITLE
Add preference to display edit/view note button either floating or in top bar

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
@@ -14,6 +14,7 @@ data class AppPreferences(
     val timeFormat: TimeFormat = defaultOf(),
     val openMediaIn: OpenMediaIn = defaultOf(),
     val showDate: ShowDate = defaultOf(),
+    val showFabChangeMode: ShowFabChangeMode = defaultOf(),
     val groupNotesWithoutNotebook: GroupNotesWithoutNotebook = defaultOf(),
     val cloudService: CloudService = defaultOf(),
     val syncMode: SyncMode = defaultOf(),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -85,6 +85,11 @@ enum class ShowDate(override val nameResource: Int) : HasNameResource, EnumPrefe
     NO(R.string.no),
 }
 
+enum class ShowFabChangeMode(override val nameResource: Int) : HasNameResource, EnumPreference by key("show_fab_change_mode") {
+    FAB(R.string.preferences_fab) { override val isDefault = true },
+    TOPBAR(R.string.preferences_top_bar),
+}
+
 enum class GroupNotesWithoutNotebook(
     override val nameResource: Int,
 ) : HasNameResource, EnumPreference by key("group_notes_without_notebook") {

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -44,6 +44,7 @@ class PreferenceRepository(
                     timeFormat = prefs.getEnum(),
                     openMediaIn = prefs.getEnum(),
                     showDate = prefs.getEnum(),
+                    showFabChangeMode = prefs.getEnum(),
                     groupNotesWithoutNotebook = prefs.getEnum(),
                     cloudService = prefs.getEnum(),
                     syncMode = prefs.getEnum(),

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -673,6 +673,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         findItem(R.id.action_pin_note)?.apply {
             setIcon(if (note.isPinned) R.drawable.ic_pin_filled else R.drawable.ic_pin)
+            setTitle(if (note.isPinned) R.string.action_unpin else R.string.action_pin)
             isVisible = !note.isDeleted
         }
 

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -371,6 +371,12 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                     activityModel.pinNotes(note)
                 }
 
+                R.id.action_change_mode -> {
+                    updateEditMode(!model.inEditMode)
+                    if (model.inEditMode) requestFocusForFields(true) else view?.hideKeyboard()
+                    setupMenuItems(note, note.reminders.isNotEmpty())
+                }
+
                 R.id.action_hide_note -> {
                     if (note.isHidden) activityModel.showNotes(note) else activityModel.hideNotes(note)
                 }
@@ -654,6 +660,15 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             title =
                 if (note.isList) getString(R.string.action_convert_to_note) else getString(R.string.action_convert_to_list)
             isVisible = !note.isDeleted
+        }
+
+        findItem(R.id.action_change_mode)?.apply {
+            // if view/edit mode FAB isn't displayed (user pref) show it in the top menu
+            if (!data.showFabChangeMode) {
+                setIcon(if (model.inEditMode) R.drawable.ic_show else R.drawable.ic_pencil)
+
+                isVisible = !note.isDeleted && !hasNoteEmptyContent(note)
+            }
         }
 
         findItem(R.id.action_pin_note)?.apply {
@@ -1063,7 +1078,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     private fun updateEditMode(inEditMode: Boolean = model.inEditMode, note: Note? = data.note) = with(binding) {
         // If the note is empty the fragment should open in edit mode by default
-        val noteHasEmptyContent = note?.content?.isBlank() == true || (note?.isList == true && note.taskList.isEmpty())
+        val noteHasEmptyContent = hasNoteEmptyContent(note)
 
         model.inEditMode = (inEditMode || noteHasEmptyContent) && !isNoteDeleted
 
@@ -1080,7 +1095,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         textViewContentPreview.isVisible = !model.inEditMode && !isList
         editTextContent.isVisible = model.inEditMode && !isList
 
-        val shouldDisplayFAB = !isNoteDeleted && !noteHasEmptyContent
+        val shouldDisplayFAB = data.showFabChangeMode && !isNoteDeleted && !noteHasEmptyContent
         when {
             fabChangeMode.isVisible == shouldDisplayFAB -> { /* FAB is already like it should be, no reason to animate */
             }
@@ -1091,6 +1106,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         fabChangeMode.setImageResource(if (model.inEditMode) R.drawable.ic_show else R.drawable.ic_pencil)
         setMarkdownToolbarVisibility(note)
+    }
+
+    private fun hasNoteEmptyContent (note: Note? = data.note) : Boolean {
+        return note?.content?.isBlank() == true || (note?.isList == true && note.taskList.isEmpty())
     }
 
     private val NoteColor.localizedName

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
@@ -32,6 +32,7 @@ import org.qosp.notes.preferences.NewNotesSyncable
 import org.qosp.notes.preferences.OpenMediaIn
 import org.qosp.notes.preferences.PreferenceRepository
 import org.qosp.notes.preferences.ShowDate
+import org.qosp.notes.preferences.ShowFabChangeMode
 import org.qosp.notes.preferences.TimeFormat
 import java.time.Instant
 import javax.inject.Inject
@@ -66,6 +67,7 @@ class EditorViewModel @Inject constructor(
                         dateTimeFormats = prefs.dateFormat to prefs.timeFormat,
                         openMediaInternally = prefs.openMediaIn == OpenMediaIn.INTERNAL,
                         showDates = prefs.showDate == ShowDate.YES,
+                        showFabChangeMode = prefs.showFabChangeMode == ShowFabChangeMode.FAB,
                         isInitialized = true,
                     )
                 }
@@ -195,6 +197,7 @@ class EditorViewModel @Inject constructor(
         val dateTimeFormats: Pair<DateFormat, TimeFormat> = defaultOf<DateFormat>() to defaultOf<TimeFormat>(),
         val openMediaInternally: Boolean = true,
         val showDates: Boolean = true,
+        val showFabChangeMode: Boolean = true,
         val isInitialized: Boolean = false,
     )
 }

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -50,6 +50,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupNoteDeletionTimeListener()
         setupBackupStrategyListener()
         setupShowDateListener()
+        setupShowFabChangeModeListener()
         setupDateFormatListener()
         setupTimeFormatListener()
         setupSyncSettingsListener()
@@ -94,6 +95,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
 
                 binding.settingGroupNotesWithoutNotebook.subText = getString(groupNotesWithoutNotebook.nameResource)
                 binding.settingShowDate.subText = getString(showDate.nameResource)
+                binding.settingShowFab.subText = getString(showFabChangeMode.nameResource)
 
                 with(DateTimeFormatter.ofPattern(getString(dateFormat.patternResource))) {
                     binding.settingDateFormat.subText = format(LocalDate.now())
@@ -180,6 +182,12 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
 
     private fun setupShowDateListener() = binding.settingShowDate.setOnClickListener {
         showPreferenceDialog(R.string.preferences_show_date, appPreferences.showDate) { selected ->
+            model.setPreference(selected)
+        }
+    }
+
+    private fun setupShowFabChangeModeListener() = binding.settingShowFab.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_show_fab_change_mode, appPreferences.showFabChangeMode) { selected ->
             model.setPreference(selected)
         }
     }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -95,6 +95,13 @@
                     app:iconSrc="@drawable/ic_date_time"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
+                android:id="@+id/setting_show_fab"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/preferences_show_fab_change_mode"
+                app:iconSrc="@drawable/ic_pencil"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_date_format"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/menu/editor_top.xml
+++ b/app/src/main/res/menu/editor_top.xml
@@ -3,6 +3,13 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <!-- Change editor between view and edit mode -->
+    <item
+        android:id="@+id/action_change_mode"
+        android:icon="@drawable/ic_show"
+        android:title="@string/action_change_mode"
+        android:visible="false"
+        app:showAsAction="ifRoom"/>
     <item
             android:id="@+id/action_pin_note"
             android:icon="@drawable/ic_pin"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,9 @@
     <string name="preferences_sort_method_modified_desc">Date modified (descending)</string>
 
     <string name="preferences_show_date">Show date created/modified</string>
+    <string name="preferences_show_fab_change_mode">Edit/View note button position</string>
+    <string name="preferences_fab">Floating button</string>
+    <string name="preferences_top_bar">Top bar</string>
     <string name="preferences_date_format">Date format</string>
     <string name="preferences_time_format">Time format</string>
 
@@ -125,6 +128,7 @@
     <string name="action_hide">Hide</string>
     <string name="action_show">Show</string>
     <string name="action_archive">Archive</string>
+    <string name="action_change_mode">Edit/View mode</string>
     <string name="action_pin">Pin</string>
     <string name="action_unpin">Unpin</string>
     <string name="action_restore">Restore</string>


### PR DESCRIPTION
As mentioned in #118, this PR adds a user preference to either show the edit/view note button floating (as FAB, current state) or in the top menu, so users with smaller devices can use this option.
Default is show as FAB, so there's no change in default behaviour.

Demo:
![FAB_option1](https://user-images.githubusercontent.com/7658194/230954482-37068fc0-8578-45b0-b379-8190ee00eb70.gif)
