### PR TITLE
Fix #140: Correct deletion messages when the "Delete notes in bin" option is set to "Never"

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -59,7 +59,7 @@ enum class NoteDeletionTime(
     NEVER(R.string.never, -1),
     INSTANTLY(R.string.preferences_note_deletion_time_instantly, 0L);
 
-    fun toDays() = TimeUnit.SECONDS.toDays(this.interval)
+    fun toDays() = if (this.interval == -1L) -1L else TimeUnit.SECONDS.toDays(this.interval)
 }
 
 enum class DateFormat(val patternResource: Int) : EnumPreference by key("date_format") {

--- a/app/src/main/java/org/qosp/notes/ui/deleted/DeletedFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/deleted/DeletedFragment.kt
@@ -66,8 +66,11 @@ class DeletedFragment : AbstractNotesFragment(R.layout.fragment_deleted) {
 
         val days = data.noteDeletionTimeInDays
 
-        binding.indicatorDeletedEmptyText.text =
-            if (days != 0L) getString(R.string.indicator_deleted_empty, days) else getString(R.string.indicator_bin_disabled)
+        binding.indicatorDeletedEmptyText.text = when (days) {
+            -1L -> getString(R.string.indicator_bin_disabled)
+            0L -> getString(R.string.indicator_bin_instantly)
+            else -> getString(R.string.indicator_deleted_empty, days)
+        }
     }
 
     override fun onNoteClick(noteId: Long, position: Int, viewBinding: LayoutNoteBinding) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,7 +168,7 @@
     <string name="empty_bin_warning_text">Alle gelöschten Notizen werden unwiderruflich gelöscht.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Notizen im Mülleimer können nicht bearbeitet werden.</string>
     <string name="indicator_deleted_empty">Ihre gelöschten Notizen werden hier für %1$d Tage erscheinen.</string>
-    <string name="indicator_bin_disabled">Notizen werden sofort gelöscht.\nSie können dieses Verhalten in den Einstellungen ändern.</string>
+    <string name="indicator_bin_instantly">Notizen werden sofort gelöscht.\nSie können dieses Verhalten in den Einstellungen ändern.</string>
     <string name="indicator_deleted_notes_permanently">Notizen unwiderruflich gelöscht.</string>
     <string name="indicator_deleted_note_permanently">Notiz unwiderruflich gelöscht.</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -134,7 +134,7 @@
     <string name="empty_bin_warning_text">Όλες οι σημειώσεις στον κάδο θα χαθούν.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Οι σημειώσεις στον κάδο μπορούν μόνο να προβληθούν.</string>
     <string name="indicator_deleted_empty">Οι διαγραμμένες σας σημειώσεις θα εμφανίζονται εδώ για %1$d μέρες.</string>
-    <string name="indicator_bin_disabled">Έχετε επιλέξει οι σημειώσεις να διαγράφονται οριστικά.\nΜπορείτε να το αλλάξετε αυτό στις ρυθμίσεις.</string>
+    <string name="indicator_bin_instantly">Έχετε επιλέξει οι σημειώσεις να διαγράφονται οριστικά.\nΜπορείτε να το αλλάξετε αυτό στις ρυθμίσεις.</string>
     <string name="indicator_deleted_notes_permanently">Σημειώσεις διαγράφηκαν οριστικά.</string>
     <string name="indicator_deleted_note_permanently">Η σημείωση διαγράφηκε οριστικά.</string>
     <string name="reminders">Υπενθυμίσεις</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,7 +153,7 @@
     <string name="empty_bin_warning_text">Todas las notas se perderán.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Las notas de la papelera no se pueden editar.</string>
     <string name="indicator_deleted_empty">Las notas eliminadas se mostrarán aquí durante %1$d días.</string>
-    <string name="indicator_bin_disabled">Las notas se eliminarán al instante.\nPuedes cambiar esto en los ajustes.</string>
+    <string name="indicator_bin_instantly">Las notas se eliminarán al instante.\nPuedes cambiar esto en los ajustes.</string>
     <string name="indicator_deleted_notes_permanently">Notas eliminadas permanentemente.</string>
     <string name="indicator_deleted_note_permanently">Nota eliminada permanentemente.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -164,7 +164,7 @@
     <string name="empty_bin_warning_text">Toutes les notes supprimées vont être perdues.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Les notes dans la corbeille ne peuvent être modifiées.</string>
     <string name="indicator_deleted_empty">Vos notes supprimées apparaîtront ici pendant %1$d jours.</string>
-    <string name="indicator_bin_disabled">Les notes sont configurées pour être immédiatement supprimées.\nVous pouvez changer cela dans les Paramètres..</string>
+    <string name="indicator_bin_instantly">Les notes sont configurées pour être immédiatement supprimées.\nVous pouvez changer cela dans les Paramètres..</string>
     <string name="indicator_deleted_notes_permanently">Les notes ont été définitivement supprimées.</string>
     <string name="indicator_deleted_note_permanently">La note a été définitvement supprimée.</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,7 +165,7 @@
     <string name="empty_bin_warning_text">Le note cestinate andranno perse.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Le note nel cestino non si possono modificare.</string>
     <string name="indicator_deleted_empty">Le tue note cestinate appariranno qui per %1$d giorni.</string>
-    <string name="indicator_bin_disabled">Note impostate per essere cancellate subito.\nPuoi cambiarlo in Impostazioni.</string>
+    <string name="indicator_bin_instantly">Note impostate per essere cancellate subito.\nPuoi cambiarlo in Impostazioni.</string>
     <string name="indicator_deleted_notes_permanently">Note cancellate.</string>
     <string name="indicator_deleted_note_permanently">Nota cancellata.</string>
 

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -166,7 +166,7 @@
     <string name="empty_bin_warning_text">Alle slettede notater vil gå tapt.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Notater i papirkurven kan ikke redigeres.</string>
     <string name="indicator_deleted_empty">Dine slettede notater vil vises her i %1$d dager.</string>
-    <string name="indicator_bin_disabled">Notater blir slettet umiddelbart.\nDu kan endre dette i innstillingene.</string>
+    <string name="indicator_bin_instantly">Notater blir slettet umiddelbart.\nDu kan endre dette i innstillingene.</string>
     <string name="indicator_deleted_notes_permanently">Notater slettet for godt.</string>
     <string name="indicator_deleted_note_permanently">Notat slettet for godt.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -164,7 +164,7 @@
     <string name="empty_bin_warning_text">Wszystkie usunięte notatki nie będą możliwe do odzyskania.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Notatki w koszu nie mogą być zmieniane.</string>
     <string name="indicator_deleted_empty">Twoje usunięte notatki pojawią się tutaj na %1$d dni.</string>
-    <string name="indicator_bin_disabled">Notatki są usuwane natychmiastowo.\nMożesz zmienić to w ustawieniach.</string>
+    <string name="indicator_bin_instantly">Notatki są usuwane natychmiastowo.\nMożesz zmienić to w ustawieniach.</string>
     <string name="indicator_deleted_notes_permanently">Usunięto notatki na stałe.</string>
     <string name="indicator_deleted_note_permanently">Usunięto notatkę na stałe.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -167,7 +167,7 @@
     <string name="empty_bin_warning_text">Todas as anotações excluídas serão perdidas.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Anotações na lixeira não podem ser editadas.</string>
     <string name="indicator_deleted_empty">Suas anotações excluídas aparecerão aqui por %1$d dias.</string>
-    <string name="indicator_bin_disabled">As anotações estão definidas para serem excluídas instantaneamente.\nVocê pode mudar isso em Configurações.</string>
+    <string name="indicator_bin_instantly">As anotações estão definidas para serem excluídas instantaneamente.\nVocê pode mudar isso em Configurações.</string>
     <string name="indicator_deleted_notes_permanently">Anotações excluídas permanentemente.</string>
     <string name="indicator_deleted_note_permanently">Anotação excluída permanentemente.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -166,7 +166,7 @@
     <string name="empty_bin_warning_text">Все удалённые заметки будут безвозвратно потеряны.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Заметки в корзине недоступны к изменению.</string>
     <string name="indicator_deleted_empty">Ваши удалённые заметки появятся тут через %1$d дней.</string>
-    <string name="indicator_bin_disabled">Вы настроили безвозвратное удаление заметок.\nМожете изменить это поведение в настройках.</string>
+    <string name="indicator_bin_instantly">Вы настроили безвозвратное удаление заметок.\nМожете изменить это поведение в настройках.</string>
     <string name="indicator_deleted_notes_permanently">Заметки удалены безвозвратно.</string>
     <string name="indicator_deleted_note_permanently">Заметка удалена безвозвратно.</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -167,7 +167,7 @@
     <string name="empty_bin_warning_text">Silinen tüm notlar kaybolacak.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Çöp kutusundaki notlar düzenlenemez.</string>
     <string name="indicator_deleted_empty">Silinen notlar %1$d gün boyunca burada görünecek.</string>
-    <string name="indicator_bin_disabled">Notlar anında silinecek şekilde ayarlanmış.\nBunu Ayarlar\'dan değiştirebilirsiniz.</string>
+    <string name="indicator_bin_instantly">Notlar anında silinecek şekilde ayarlanmış.\nBunu Ayarlar\'dan değiştirebilirsiniz.</string>
     <string name="indicator_deleted_notes_permanently">Notlar kalıcı olarak silindi.</string>
     <string name="indicator_deleted_note_permanently">Not kalıcı olarak silindi.</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -167,7 +167,7 @@
     <string name="empty_bin_warning_text">Усі видалені нотатки будуть втрачені назавжди.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Нотатки у смітнику не можуть бути змінені.</string>
     <string name="indicator_deleted_empty">Видалені вами нотатки, існуватимуть у смітнику зо %1$d діб.</string>
-    <string name="indicator_bin_disabled">Смітник
+    <string name="indicator_bin_instantly">Смітник
     налаштований на миттєве видалення нотатків.\nВи можете змінити це у налаштуваннях.</string>
     <string name="indicator_deleted_notes_permanently">Нотатки видалено назавжди.</string>
     <string name="indicator_deleted_note_permanently">Нотаток видалено назавжди.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -167,7 +167,7 @@
     <string name="empty_bin_warning_text">所有已删除的笔记都将丢失。</string>
     <string name="indicator_deleted_note_cannot_be_edited">无法编辑废纸篓中的注释。</string>
     <string name="indicator_deleted_empty">您删除的笔记将显示在此处 %1$d 天。</string>
-    <string name="indicator_bin_disabled">笔记设置为立即删除。\n您可以在设置中更改此设置。</string>
+    <string name="indicator_bin_instantly">笔记设置为立即删除。\n您可以在设置中更改此设置。</string>
     <string name="indicator_deleted_notes_permanently">彻底删除笔记。</string>
     <string name="indicator_deleted_note_permanently">彻底删除笔记。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,7 +171,8 @@
     <string name="empty_bin_warning_text">All deleted notes will be lost.</string>
     <string name="indicator_deleted_note_cannot_be_edited">Notes inside the bin cannot be edited.</string>
     <string name="indicator_deleted_empty">Your deleted notes will appear here for %1$d days.</string>
-    <string name="indicator_bin_disabled">Notes are set to be deleted instantly.\nYou can change this at Settings.</string>
+    <string name="indicator_bin_disabled">Notes are set to be never deleted.\nYou can change this at Settings.</string>
+    <string name="indicator_bin_instantly">Notes are set to be instantly deleted.\nYou can change this at Settings.</string>
     <string name="indicator_deleted_notes_permanently">Deleted notes permanently.</string>
     <string name="indicator_deleted_note_permanently">Deleted note permanently.</string>
 


### PR DESCRIPTION
Demo:
![del msgs](https://github.com/quillpad/quillpad/assets/7658194/cfe5a9a1-52e8-4129-bd1a-ce362fe10508)

Handling the localization (translations) was a bit tricky in this case, because original coder put wrong default text for `indicator_bin_disabled`: "Notes are set to be deleted instantly..." (https://github.com/nofishonfriday/quillpad/commit/82e158d4452fa52dc275e0e552915f79bba753f1#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103L174).
So all translations were wrong following this.
I've moved the existing translations to the new `indicator_bin_instantly`, so translations for `indicator_bin_disabled` need to be redone.

closes #140