### PR TITLE
Add menu items to set compact/full preview for multiple selected notes at once

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
@@ -137,6 +137,18 @@ class ActivityViewModel @Inject constructor(
         )
     }
 
+    fun compactPreviewNotes(vararg notes: Note) = update(*notes) { note ->
+        note.copy(
+            isCompactPreview = true,
+        )
+    }
+
+    fun fullPreviewNotes(vararg notes: Note) = update(*notes) { note ->
+        note.copy(
+            isCompactPreview = false,
+        )
+    }
+
     fun moveNotes(notebookId: Long?, vararg notes: Note) = update(*notes) { note ->
         note.copy(
             notebookId = notebookId,

--- a/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
@@ -336,6 +336,8 @@ abstract class AbstractNotesFragment(@LayoutRes resId: Int) : BaseFragment(resId
 
             when (item.itemId) {
                 R.id.action_pin_selected -> activityModel.pinNotes(*selectedNotes)
+                R.id.action_compact_preview_selected -> activityModel.compactPreviewNotes(*selectedNotes)
+                R.id.action_full_preview_selected -> activityModel.fullPreviewNotes(*selectedNotes)
                 R.id.action_archive_selected -> {
                     activityModel.archiveNotes(*selectedNotes)
                     sendMessage(

--- a/app/src/main/res/menu/main_selected_notes.xml
+++ b/app/src/main/res/menu/main_selected_notes.xml
@@ -6,6 +6,14 @@
             android:title="@string/action_pin_unpin"
             app:showAsAction="never"/>
     <item
+        android:id="@+id/action_compact_preview_selected"
+        android:title="@string/action_compact_preview"
+        app:showAsAction="never"/>
+    <item
+        android:id="@+id/action_full_preview_selected"
+        android:title="@string/action_full_preview"
+        app:showAsAction="never"/>
+    <item
             android:id="@+id/action_archive_selected"
             android:title="@string/action_archive"
             app:showAsAction="never"/>


### PR DESCRIPTION
Demo:
![bulk full compact preview](https://github.com/quillpad/quillpad/assets/7658194/774f0a57-1a91-4e3f-8603-3c989e51ecfe)
