### PR TITLE
Fix order of tasks in checklist

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -1019,17 +1019,36 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     private fun updateTask(position: Int, content: String? = null, isDone: Boolean? = null) {
         val tasks = tasksAdapter.tasks
-        val task = tasks[position].let {
-            it.copy(
-                content = content ?: it.content,
-                isDone = isDone ?: it.isDone
-            )
+        val oldTask = tasks[position]
+        val newTask = tasks[position].copy(
+            content = content ?: oldTask.content,
+            isDone = isDone ?: oldTask.isDone
+        )
+        tasks[position] = newTask
+
+        if (oldTask.isDone != newTask.isDone) {
+            if (newTask.isDone) {
+                // Move to very end
+                tasks.removeAt(position)
+                tasks.add(newTask)
+
+                tasksAdapter.notifyItemMoved(position, tasks.indexOf(newTask))
+                tasksAdapter.notifyItemRangeChanged(position, tasks.size - position)
+            } else {
+                // Move to after last open task or to very beginning if all tasks are done
+                val newPosition = tasks.indexOfLast { it.id != newTask.id && ! it.isDone } + 1
+
+                // Only move upwards; don't move further down
+                if (newPosition < position) {
+                    tasks.removeAt(position)
+                    tasks.add(newPosition, newTask)
+
+                    tasksAdapter.notifyItemMoved(position, newPosition)
+                    tasksAdapter.notifyItemRangeChanged(newPosition, position - newPosition + 1)
+                }
+            }
         }
-        tasks[position] = task
-        val notCompleted = tasks.filterNot { it.isDone }.sortedBy { it.id }
-        val completed = tasks.filter { it.isDone }.sortedBy { it.id }
-        tasksAdapter.tasks = (notCompleted + completed).toMutableList()
-        tasksAdapter.notifyItemMoved(position, tasksAdapter.tasks.indexOf(task))
+
         model.updateTaskList(tasksAdapter.tasks)
     }
 


### PR DESCRIPTION
This PR fixes the order of tasks. When modifying (check/uncheck/text) a single task, all tasks are being reordered upon reopening the note. See #110 and #159 for more details on the problem.

Old logic (currently):
  - when a task is modified (check/uncheck/text-change), reorder all tasks to their initial order but display done/checked tasks last

New logic (in PR):
  - when a task is modified (text-change) only change the content of that task
  - when a task is modified (check/uncheck)
    - if the task is now done/checked move it to the very bottom
    - if the task is now open/unchecked move it to after the last open task

Fixes #110 
Fixes #159

This is my first time contributing to Quillpad and to an Android App in general. So I'd appreciate it if you could have a look :)