### PR TITLE
Add Text editor/view font size preference

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
@@ -14,6 +14,7 @@ data class AppPreferences(
     val timeFormat: TimeFormat = defaultOf(),
     val openMediaIn: OpenMediaIn = defaultOf(),
     val showDate: ShowDate = defaultOf(),
+    val editorFontSize: FontSize = defaultOf(),
     val showFabChangeMode: ShowFabChangeMode = defaultOf(),
     val groupNotesWithoutNotebook: GroupNotesWithoutNotebook = defaultOf(),
     val moveCheckedItems: MoveCheckedItems = defaultOf(),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -85,6 +85,22 @@ enum class ShowDate(override val nameResource: Int) : HasNameResource, EnumPrefe
     NO(R.string.no),
 }
 
+// TODO (maybe): make this a number input dialog rather than radio buttons choice
+enum class FontSize(
+    override val nameResource: Int, val fontSize: Int
+) : HasNameResource, EnumPreference by key("editor_font_size") {
+    DEFAULT(R.string.preferences_font_size_default, -1) { override val isDefault = true }, // uses predefined/default MaterialComponents.Body1 font size
+    TEN(R.string.preferences_font_size_ten, 10),
+    FIFTEEN(R.string.preferences_font_size_fifteen, 15),
+    TWENTY(R.string.preferences_font_size_twenty, 20),
+    TWENTYFIVE(R.string.preferences_font_size_twentyfive, 25),
+    THIRTY(R.string.preferences_font_size_thirty, 30),
+    THIRTYFIVE(R.string.preferences_font_size_thirtyfive, 35),
+    FORTY(R.string.preferences_font_size_forty, 40),
+    FORTYFIVE(R.string.preferences_font_size_fortyfive, 45),
+    FIFTY(R.string.preferences_font_size_fifty, 50),
+}
+
 enum class ShowFabChangeMode(override val nameResource: Int) : HasNameResource, EnumPreference by key("show_fab_change_mode") {
     FAB(R.string.preferences_fab) { override val isDefault = true },
     TOPBAR(R.string.preferences_top_bar),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -44,6 +44,7 @@ class PreferenceRepository(
                     timeFormat = prefs.getEnum(),
                     openMediaIn = prefs.getEnum(),
                     showDate = prefs.getEnum(),
+                    editorFontSize = prefs.getEnum(),
                     showFabChangeMode = prefs.getEnum(),
                     groupNotesWithoutNotebook = prefs.getEnum(),
                     moveCheckedItems = prefs.getEnum(),

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -730,6 +730,21 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             // Update Title and Content only the first the since they are EditTexts
             if (isFirstLoad) {
 
+                // apply font size preference
+                if (data.editorFontSize != -1) { // is customised
+                    val fontSizeFloat =  data.editorFontSize.toFloat()
+
+                    textViewTitlePreview.textSize = fontSizeFloat
+                    textViewContentPreview.textSize = fontSizeFloat
+
+                    editTextTitle.textSize = fontSizeFloat
+                    editTextContent.textSize = fontSizeFloat
+
+                    if (isList) {
+                        tasksAdapter.setFontSize(fontSizeFloat)
+                    }
+                }
+
                 editTextTitle.withoutTextWatchers {
                     setText(data.note.title)
                 }
@@ -754,6 +769,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
             // We only want to update the task list when the user converts the note from text to list
             if (isConverted) {
+
+                if (data.editorFontSize != -1) {
+                    tasksAdapter.setFontSize(data.editorFontSize.toFloat())
+                }
+
                 tasksAdapter.tasks.clear()
                 tasksAdapter.notifyDataSetChanged()
                 tasksAdapter.submitList(data.note.taskList)

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
@@ -62,6 +62,7 @@ class EditorViewModel @Inject constructor(
                         dateTimeFormats = prefs.dateFormat to prefs.timeFormat,
                         openMediaInternally = prefs.openMediaIn == OpenMediaIn.INTERNAL,
                         showDates = prefs.showDate == ShowDate.YES,
+                        editorFontSize = prefs.editorFontSize.fontSize,
                         showFabChangeMode = prefs.showFabChangeMode == ShowFabChangeMode.FAB,
                         isInitialized = true,
                     )
@@ -193,6 +194,7 @@ class EditorViewModel @Inject constructor(
         val dateTimeFormats: Pair<DateFormat, TimeFormat> = defaultOf<DateFormat>() to defaultOf<TimeFormat>(),
         val openMediaInternally: Boolean = true,
         val showDates: Boolean = true,
+        val editorFontSize: Int = -1, // -1: not customised, default font size
         val showFabChangeMode: Boolean = true,
         val isInitialized: Boolean = false,
         val moveCheckedItems: Boolean = true,

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -51,6 +51,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupNoteDeletionTimeListener()
         setupBackupStrategyListener()
         setupShowDateListener()
+        setupShowFontSizeListener()
         setupShowFabChangeModeListener()
         setupDateFormatListener()
         setupTimeFormatListener()
@@ -97,6 +98,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
                 binding.settingGroupNotesWithoutNotebook.subText = getString(groupNotesWithoutNotebook.nameResource)
                 binding.settingMoveCheckedItems.subText = getString(moveCheckedItems.nameResource)
                 binding.settingShowDate.subText = getString(showDate.nameResource)
+                binding.settingFontSize.subText = getString(editorFontSize.nameResource)
                 binding.settingShowFab.subText = getString(showFabChangeMode.nameResource)
 
                 with(DateTimeFormatter.ofPattern(getString(dateFormat.patternResource))) {
@@ -190,6 +192,12 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
 
     private fun setupShowDateListener() = binding.settingShowDate.setOnClickListener {
         showPreferenceDialog(R.string.preferences_show_date, appPreferences.showDate) { selected ->
+            model.setPreference(selected)
+        }
+    }
+
+    private fun setupShowFontSizeListener() = binding.settingFontSize.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_font_size, appPreferences.editorFontSize) { selected ->
             model.setPreference(selected)
         }
     }

--- a/app/src/main/java/org/qosp/notes/ui/tasks/TasksAdapter.kt
+++ b/app/src/main/java/org/qosp/notes/ui/tasks/TasksAdapter.kt
@@ -15,6 +15,8 @@ class TasksAdapter(
     private val markwon: Markwon,
 ) : RecyclerView.Adapter<TaskViewHolder>() {
 
+    private var fontSize: Float = -1.0f
+
     var tasks: MutableList<NoteTask> = mutableListOf()
 
     override fun getItemCount(): Int = tasks.size
@@ -22,6 +24,16 @@ class TasksAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder {
         val binding: LayoutTaskBinding =
             LayoutTaskBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        // apply font size preference
+        binding.editText.textSize = fontSize
+        // checkboxes are only downscaled, because upscaled looks blurry
+        val checkBoxScaleRatio: Float = fontSize / 16 // 16 because by default edit_text uses MaterialComponents.Body1 = 16sp
+        if (checkBoxScaleRatio < 1.0) {
+            binding.checkBox.scaleX = checkBoxScaleRatio
+            binding.checkBox.scaleY = checkBoxScaleRatio
+        }
+
         return TaskViewHolder(parent.context, binding, listener, inPreview, markwon)
     }
 
@@ -42,6 +54,10 @@ class TasksAdapter(
                 result.dispatchUpdatesTo(this)
             }
         }
+    }
+
+    fun setFontSize(fs: Float) {
+        fontSize = fs
     }
 
     private class DiffCallback(val oldList: List<NoteTask>, val newList: List<NoteTask>) : DiffUtil.Callback() {

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -29,6 +29,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
+            <!-- General -->
             <TextView
                     android:text="@string/preferences_header_general"
                     android:textStyle="bold"
@@ -64,14 +65,25 @@
                     android:layout_height="1dp"
                     android:background="?attr/colorOutline"/>
 
+            <!-- View -->
+            <!-- Notebook -->
             <TextView
                     android:text="@string/preferences_header_view"
                     android:textStyle="bold"
                     android:fontFamily="@font/inter_font_family"
                     android:textColor="?attr/colorPrimary"
-                    android:padding="16dp"
+                    android:paddingTop="16dp"
+                    android:paddingLeft="16dp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
+
+            <TextView
+                android:text="@string/preferences_header_view_notebook"
+                android:fontFamily="@font/inter_font_family"
+                android:textColor="?attr/colorSecondary"
+                android:padding="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_layout_mode"
@@ -87,12 +99,14 @@
                     app:text="@string/preferences_sort_method"
                     app:iconSrc="@drawable/ic_sort"/>
 
-            <org.qosp.notes.ui.utils.views.PreferenceView
-                    android:id="@+id/setting_show_date"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:text="@string/preferences_show_date"
-                    app:iconSrc="@drawable/ic_date_time"/>
+            <!-- Note content -->
+            <TextView
+                android:text="@string/preferences_header_view_note_content"
+                android:fontFamily="@font/inter_font_family"
+                android:textColor="?attr/colorSecondary"
+                android:padding="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
                 android:id="@+id/setting_font_size"
@@ -107,6 +121,13 @@
                 android:layout_height="wrap_content"
                 app:text="@string/preferences_show_fab_change_mode"
                 app:iconSrc="@drawable/ic_pencil"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
+                    android:id="@+id/setting_show_date"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:text="@string/preferences_show_date"
+                    app:iconSrc="@drawable/ic_date_time"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_date_format"
@@ -127,6 +148,7 @@
                     android:layout_height="1dp"
                     android:background="?attr/colorOutline"/>
 
+            <!-- Other -->
             <TextView
                     android:text="@string/preferences_header_other"
                     android:textStyle="bold"
@@ -169,6 +191,7 @@
                     android:layout_height="1dp"
                     android:background="?attr/colorOutline"/>
 
+            <!-- Backup -->
             <TextView
                     android:text="@string/preferences_header_backup"
                     android:textStyle="bold"
@@ -206,6 +229,7 @@
                     android:layout_height="1dp"
                     android:background="?attr/colorOutline"/>
 
+            <!-- Syncing -->
             <TextView
                     android:text="@string/preferences_header_syncing"
                     android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -95,6 +95,13 @@
                     app:iconSrc="@drawable/ic_date_time"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
+                android:id="@+id/setting_font_size"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/preferences_font_size"
+                app:iconSrc="@drawable/ic_search"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
                 android:id="@+id/setting_show_fab"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="nav_your_notebooks">Your Notebooks</string>
 
     <!-- Preferences -->
+    <!-- Preferences / General -->
     <string name="preferences_header_general">General</string>
     <string name="preferences_theme_mode">Theme mode</string>
     <string name="preferences_theme_mode_dark">Dark</string>
@@ -21,11 +22,6 @@
     <string name="preferences_theme_dark_mode_standard">Standard</string>
     <string name="preferences_theme_dark_mode_black">Black</string>
 
-    <string name="preferences_header_view">View</string>
-    <string name="preferences_layout_mode">Layout mode</string>
-    <string name="preferences_layout_mode_grid">Grid</string>
-    <string name="preferences_layout_mode_list">List</string>
-
     <string name="preferences_color_scheme">Color scheme</string>
     <string name="preferences_color_scheme_blue">Blue</string>
     <string name="preferences_color_scheme_pink">Pink</string>
@@ -35,6 +31,16 @@
     <string name="preferences_color_scheme_yellow">Yellow</string>
     <string name="preferences_color_scheme_red">Red</string>
 
+    <!-- Preferences / View -->
+    <string name="preferences_header_view">View</string>
+
+    <!-- Preferences / View / Notebook -->
+    <string name="preferences_header_view_notebook">Notebook</string>
+
+    <string name="preferences_layout_mode">Layout mode</string>
+    <string name="preferences_layout_mode_grid">Grid</string>
+    <string name="preferences_layout_mode_list">List</string>
+
     <string name="preferences_sort_method">Sort by</string>
     <string name="preferences_sort_method_title_asc">Title (ascending)</string>
     <string name="preferences_sort_method_title_desc">Title (descending)</string>
@@ -43,7 +49,8 @@
     <string name="preferences_sort_method_modified_asc">Date modified (ascending)</string>
     <string name="preferences_sort_method_modified_desc">Date modified (descending)</string>
 
-    <string name="preferences_show_date">Show date created/modified</string>
+    <!-- Preferences / View / Note content -->
+    <string name="preferences_header_view_note_content">Note content</string>
 
     <string name="preferences_font_size">Text editor/view font size</string>
     <string name="preferences_font_size_default">Default</string>
@@ -60,21 +67,29 @@
     <string name="preferences_show_fab_change_mode">Edit/View note button position</string>
     <string name="preferences_fab">Floating button</string>
     <string name="preferences_top_bar">Top bar</string>
+
+    <string name="preferences_show_date">Show date created/modified</string>
     <string name="preferences_date_format">Date format</string>
     <string name="preferences_time_format">Time format</string>
 
+    <!-- Preferences / Other -->
     <string name="preferences_header_other">Other</string>
-    <string name="preferences_group_notes_without_notebook">Group notes which are not in any notebook</string>
-    <string name="preferences_move_checked_items">Move (un)checked items in the lists</string>
+
     <string name="preferences_open_media_in">Open media in</string>
     <string name="preferences_open_media_in_internal">Internal player</string>
     <string name="preferences_open_media_in_external">External player</string>
+
+    <string name="preferences_group_notes_without_notebook">Group notes which are not in any notebook</string>
+
+    <string name="preferences_move_checked_items">Move (un)checked items in the lists</string>
+
     <string name="preferences_note_deletion_time">Delete notes in bin</string>
     <string name="preferences_note_deletion_time_instantly">Instantly</string>
     <string name="preferences_note_deletion_time_week">After 7 days</string>
     <string name="preferences_note_deletion_time_two_weeks">After 14 days</string>
     <string name="preferences_note_deletion_time_month">After 30 days</string>
 
+    <!-- Preferences / Backup -->
     <string name="preferences_header_backup">Backup</string>
     <string name="preferences_create_backup">Create a backup</string>
     <string name="preferences_create_backup_subtext">Export all notes to a backup file.</string>
@@ -85,6 +100,7 @@
     <string name="preferences_backup_strategy_keep_info">Only backup description and local path</string>
     <string name="preferences_backup_strategy_keep_nothing">Do not backup attachments</string>
 
+    <!-- Preferences / Syncing -->
     <string name="preferences_header_syncing">Syncing</string>
     <string name="preferences_go_to_sync_settings">Go to sync settings</string>
     <string name="preferences_currently_syncing_with">Currently syncing with %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,19 @@
     <string name="preferences_sort_method_modified_desc">Date modified (descending)</string>
 
     <string name="preferences_show_date">Show date created/modified</string>
+
+    <string name="preferences_font_size">Text editor/view font size</string>
+    <string name="preferences_font_size_default">Default</string>
+    <string name="preferences_font_size_ten">10</string>
+    <string name="preferences_font_size_fifteen">15</string>
+    <string name="preferences_font_size_twenty">20</string>
+    <string name="preferences_font_size_twentyfive">25</string>
+    <string name="preferences_font_size_thirty">30</string>
+    <string name="preferences_font_size_thirtyfive">35</string>
+    <string name="preferences_font_size_forty">40</string>
+    <string name="preferences_font_size_fortyfive">45</string>
+    <string name="preferences_font_size_fifty">50</string>
+
     <string name="preferences_show_fab_change_mode">Edit/View note button position</string>
     <string name="preferences_fab">Floating button</string>
     <string name="preferences_top_bar">Top bar</string>


### PR DESCRIPTION
Demo (work in progress):
![change fontsize](https://github.com/quillpad/quillpad/assets/7658194/7523e569-45a0-42b0-9bfc-a960cee8095c)

Currently it only changes the font size of the editor/view text, not sure if there should be seperate settings for e.g. preview font size or it should affect all text in the app (maybe too much work)?

And yes, imo it would be better to have a number (integer) text input (or e.g. a slider) instead of option (radio) buttons to set stepless font size, but I'm not capable of and won't do (but appreciate if someone wants to cooperate on this PR). :)   

related issues: #75, #99


