### PR TITLE
(Re-)Fix disappearing/not updating checklist entries (#235)

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -1038,7 +1038,6 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     }
 
     private fun updateTask(position: Int, content: String? = null, isDone: Boolean? = null) {
-        if (!model.moveCheckedItems) return
         val tasks = tasksAdapter.tasks
         val oldTask = tasks[position]
         val newTask = tasks[position].copy(


### PR DESCRIPTION
Fixes #235

The fix (removal of the `if (!model.moveCheckedItems) return` line) was already submitted/merged in https://github.com/quillpad/quillpad/commit/90db9ff8933f0bd3338239fde92823bbcc6d50d7 but then seems it somehow got lost in https://github.com/quillpad/quillpad/commit/547a3e4543843df6aaf96da70cb58c57982bd853. 

This PR removes the line again restoring the original fix submitted by @fabix.