### PR TITLE
Prevent crash caused by using SCHEDULE_EXACT_ALARM permission on Android 14+ (#231)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application


### PR DESCRIPTION
Fixes #231

There's a (imo) bit confusing [topic](https://stackoverflow.com/questions/71031091/android-12-using-schedule-exact-alarm-permission-to-get-show-data-at-specific-t) about this on Stack Overflow saying that `permission.USE_EXACT_ALARM` is only allowed to use for e.g. calendar apps needing to exactly fire a user alarm/notification. Not sure if Quillpad qualifies for this.