### PR TITLE
Add permissions for foreground services on Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,4 +85,11 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+                   android:minSdkVersion="34"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"
+                   android:minSdkVersion="34"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+                   android:minSdkVersion="34"/>
+
 </manifest>


### PR DESCRIPTION
Android 14 requires foreground services to declare types and declare appropriate permissions. While Quillpad defines the types, it doesn't declare the permissions. This commit adds the declarations.

This should, in theory, fix #266, but I haven't tested it as I kept getting Room errors (to clarify, the app was built, but crashed with an error about AppDatabase_impl when launched - I assume this is an issue with my configuration and not the commit).