### PR TITLE
Make cursor/focus default to note body (rather than note title) for new notes

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -1123,15 +1123,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         return true
     }
 
-    /** Gives the focus to the editor fields if they are empty */
+    /** Gives the focus to the note body if it is empty */
     private fun requestFocusForFields(forceFocus: Boolean = false) = with(binding) {
-        // Don't set focus to title if already auto-set to 'Untitled' (probably user doesn't want to set title)
-        if (editTextTitle.text.isNullOrEmpty() && textViewTitlePreview.text.toString() != getString(R.string.indicator_untitled).toString()) {
-            editTextTitle.requestFocusAndKeyboard()
-        } else {
-            if (editTextContent.text.isNullOrEmpty() || forceFocus) {
-                editTextContent.requestFocusAndKeyboard()
-            }
+        if (editTextContent.text.isNullOrEmpty() || forceFocus) {
+            editTextContent.requestFocusAndKeyboard()
         }
     }
 


### PR DESCRIPTION
closes #274

![QP](https://github.com/quillpad/quillpad/assets/7658194/88c452c1-0d98-463a-87b2-a3af00e20749)

APKs for testing available here:
https://github.com/quillpad/quillpad/actions/runs/8988246519/artifacts/1480834695