### PR TITLE
Show original error message (rather than just 'Something went wrong') when Nextcloud sync fails to connect due to an unknown error

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/sync/nextcloud/NextcloudAccountDialog.kt
+++ b/app/src/main/java/org/qosp/notes/ui/sync/nextcloud/NextcloudAccountDialog.kt
@@ -67,8 +67,13 @@ class NextcloudAccountDialog : BaseDialog<DialogNextcloudAccountBinding>() {
                     Unauthorized -> R.string.message_invalid_credentials
                     else -> R.string.message_something_went_wrong
                 }
-                Toast.makeText(requireContext(), getString(messageResId), Toast.LENGTH_SHORT).show()
-                if (result == Success) dismiss()
+                if (messageResId != R.string.message_something_went_wrong) { // known error or success
+                    Toast.makeText(requireContext(), getString(messageResId), Toast.LENGTH_SHORT).show()
+                    if (result == Success) dismiss()
+                } else { // unknown error
+                    val text = getString(R.string.message_something_went_wrong) + "\n" + result.message
+                    Toast.makeText(requireContext(), text, Toast.LENGTH_LONG).show()
+                }
             }
         }
 


### PR DESCRIPTION
closes #259

Demo:
![NC](https://github.com/quillpad/quillpad/assets/7658194/8ee5f08f-79cc-4c2a-bae1-39700fcd7326)

Before this change, the toast would have shown only (imo rather unhelpful) `Something went wrong.` text.
