### PR TITLE
Fix Material You colors

### DIFF
--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -3,7 +3,7 @@
     <style name="System">
         <item name="colorPrimary">@android:color/system_accent1_200</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorSecondary">@android:color/system_accent2_800</item>
+        <item name="colorSecondary">@android:color/system_accent2_200</item>
         <item name="colorBackground">@android:color/system_neutral2_900</item>
         <item name="colorSurface">@android:color/system_neutral2_900</item>
         <item name="colorDrawerHeaderBackground">@android:color/system_accent1_600</item>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -3,7 +3,7 @@
     <style name="System">
         <item name="colorPrimary">@android:color/system_accent1_500</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorSecondary">@android:color/system_accent2_200</item>
+        <item name="colorSecondary">@android:color/system_accent2_500</item>
         <item name="colorBackground">@android:color/system_neutral2_50</item>
         <item name="colorSurface">@android:color/system_neutral2_100</item>
         <item name="colorDrawerHeaderBackground">@android:color/system_accent1_300</item>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -8,7 +8,7 @@
         <item name="colorSurface">@android:color/system_neutral2_300</item>
         <item name="colorDrawerHeaderBackground">@android:color/system_accent1_300</item>
         <item name="colorPrimaryTranscluent">@android:color/system_accent1_200</item>
-        <item name="colorNoteDefault">@android:color/system_neutral2_800</item>
+        <item name="colorNoteDefault">@android:color/system_neutral2_300</item>
         <item name="colorDrawerBackground">@android:color/system_neutral1_200</item>
         <item name="colorBottomAppBarBackground">@android:color/system_neutral2_200</item>
     </style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -4,12 +4,12 @@
         <item name="colorPrimary">@android:color/system_accent1_500</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
         <item name="colorSecondary">@android:color/system_accent2_200</item>
-        <item name="colorBackground">@android:color/system_neutral2_200</item>
-        <item name="colorSurface">@android:color/system_neutral2_300</item>
+        <item name="colorBackground">@android:color/system_neutral2_50</item>
+        <item name="colorSurface">@android:color/system_neutral2_100</item>
         <item name="colorDrawerHeaderBackground">@android:color/system_accent1_300</item>
         <item name="colorPrimaryTranscluent">@android:color/system_accent1_200</item>
-        <item name="colorNoteDefault">@android:color/system_neutral2_300</item>
-        <item name="colorDrawerBackground">@android:color/system_neutral1_200</item>
-        <item name="colorBottomAppBarBackground">@android:color/system_neutral2_200</item>
+        <item name="colorNoteDefault">@android:color/system_neutral2_100</item>
+        <item name="colorDrawerBackground">@android:color/system_neutral1_50</item>
+        <item name="colorBottomAppBarBackground">@android:color/system_neutral2_50</item>
     </style>
 </resources>


### PR DESCRIPTION
This pull request fixes #307 and adds correct colors in light mode:

<img src="https://github.com/user-attachments/assets/93f5d3d0-d821-456e-ae91-06851ae0c02b" alt="List showing 2 notes: one called Cool list with a list and another saying The quick brown fox jumps over the lazy dog." width="400">
<img src="https://github.com/user-attachments/assets/3371bced-a886-45ed-877b-ce02bcaaca9a" alt="Note called Cool list with 2 items in a checklist: Something else and Something (checked)" width="400">

#301 is also fixed:

<img src="https://github.com/user-attachments/assets/054ee475-b689-4d82-b7b2-d558a31be971" alt="Note saying I take notes using Quillpad, an open source app. The word Quillpad is highlighted." width="600">
