### PR TITLE
Uncheck all tasks functionality

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -438,6 +438,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                     setupScreenAlwaysOn(!note.screenAlwaysOn)
                 }
 
+//                R.id.action_uncheck_all_tasks -> {
+//                    uncheckAllTasks()
+//                    true
+//                }
+
                 else -> false
             }
         }
@@ -723,6 +728,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             isChecked = note.screenAlwaysOn
             isVisible = !note.isDeleted
         }
+
+//        findItem(R.id.action_uncheck_all_tasks)?.apply {
+//            isVisible = note.isList && !note.isDeleted
+//        }
     }
 
     private fun observeData() = with(binding) {
@@ -1197,6 +1206,15 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     private fun hasNoteEmptyContent(note: Note? = data.note): Boolean {
         return note?.content?.isBlank() == true || (note?.isList == true && note.taskList.isEmpty())
     }
+
+//    private fun uncheckAllTasks() {
+//        val updatedTasks = tasksAdapter.tasks.map { task ->
+//            task.copy(isDone = false)
+//        }
+//        tasksAdapter.submitList(updatedTasks)
+//
+//        model.updateTaskList(updatedTasks)
+//    }
 
     private val NoteColor.localizedName
         get() = getString(

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -438,10 +438,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                     setupScreenAlwaysOn(!note.screenAlwaysOn)
                 }
 
-//                R.id.action_uncheck_all_tasks -> {
-//                    uncheckAllTasks()
-//                    true
-//                }
+                R.id.action_uncheck_all_tasks -> {
+                    uncheckAllTasks()
+                    true
+                }
 
                 else -> false
             }
@@ -729,9 +729,9 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             isVisible = !note.isDeleted
         }
 
-//        findItem(R.id.action_uncheck_all_tasks)?.apply {
-//            isVisible = note.isList && !note.isDeleted
-//        }
+        findItem(R.id.action_uncheck_all_tasks)?.apply {
+            isVisible = note.isList && !note.isDeleted
+        }
     }
 
     private fun observeData() = with(binding) {
@@ -1207,14 +1207,14 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         return note?.content?.isBlank() == true || (note?.isList == true && note.taskList.isEmpty())
     }
 
-//    private fun uncheckAllTasks() {
-//        val updatedTasks = tasksAdapter.tasks.map { task ->
-//            task.copy(isDone = false)
-//        }
-//        tasksAdapter.submitList(updatedTasks)
-//
-//        model.updateTaskList(updatedTasks)
-//    }
+    private fun uncheckAllTasks() {
+        val updatedTasks = tasksAdapter.tasks.map { task ->
+            task.copy(isDone = false)
+        }
+        tasksAdapter.submitList(updatedTasks)
+
+        model.updateTaskList(updatedTasks)
+    }
 
     private val NoteColor.localizedName
         get() = getString(

--- a/app/src/main/res/menu/editor_top.xml
+++ b/app/src/main/res/menu/editor_top.xml
@@ -46,7 +46,6 @@
     <item
         android:id="@+id/action_uncheck_all_tasks"
         android:title="@string/action_uncheck_all_tasks"
-        android:icon="@drawable/ic_restore"
         android:visible="true"
         app:showAsAction="ifRoom"/>
     <item

--- a/app/src/main/res/menu/editor_top.xml
+++ b/app/src/main/res/menu/editor_top.xml
@@ -44,6 +44,12 @@
             android:visible="false"
             app:showAsAction="never"/>
     <item
+        android:id="@+id/action_uncheck_all_tasks"
+        android:title="@string/action_uncheck_all_tasks"
+        android:icon="@drawable/ic_restore"
+        android:visible="true"
+        app:showAsAction="ifRoom"/>
+    <item
             android:id="@+id/action_delete_note"
             android:title="@string/action_delete"
             android:visible="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="action_insert_heading">Insert heading markdown</string>
     <string name="action_insert_quote">Insert quotation markdown</string>
     <string name="action_insert_code">Insert code markdown</string>
+    <string name="action_uncheck_all_tasks">Uncheck all tasks</string>
     <string name="indicator_note_date">Created at %1$s\nLast modified at %2$s</string>
     <string name="indicator_restored_notes">Restored notes</string>
     <string name="indicator_restored_note">Restored note</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
     <string name="action_insert_heading">Insert heading markdown</string>
     <string name="action_insert_quote">Insert quotation markdown</string>
     <string name="action_insert_code">Insert code markdown</string>
-    <string name="action_uncheck_all_tasks">Uncheck all tasks</string>
+    <string name="action_uncheck_all_tasks">Uncheck all items</string>
     <string name="indicator_note_date">Created at %1$s\nLast modified at %2$s</string>
     <string name="indicator_restored_notes">Restored notes</string>
     <string name="indicator_restored_note">Restored note</string>


### PR DESCRIPTION
## Summary
This pull request adds an option for users to uncheck all items of the opened list-note at once. This is especially convenient when reusing an existing list, as it eliminates the need to manually uncheck each item of the list.

## Related issues
Fixes #176 

## Changes

- When in editor view of a list-note, an option in the top-menu is added called "Uncheck all items". This option unchecks all items in the list of that note.


https://github.com/user-attachments/assets/1a5131b9-d0cf-489e-940f-9f2470822959