### PR TITLE
Notebook and tag list sorter (#44, #77, and #184)

### DIFF
--- a/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
+++ b/app/src/main/java/org/qosp/notes/di/MarkwonModule.kt
@@ -62,7 +62,7 @@ object MarkwonModule {
                         SpanFactory { _, _ ->
                             val typedValue = TypedValue()
                             context.theme.resolveAttribute(R.attr.colorNoteTextHighlight, typedValue, true)
-                            val color = typedValue.data;
+                            val color = typedValue.data
                             return@SpanFactory BackgroundColorSpan(color)
                         })
             })

--- a/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
@@ -8,6 +8,8 @@ data class AppPreferences(
     val darkThemeMode: DarkThemeMode = defaultOf(),
     val colorScheme: ColorScheme = defaultOf(),
     val sortMethod: SortMethod = defaultOf(),
+    val sortTagsMethod: SortTagsMethod = defaultOf(),
+    val sortNavdrawerNotebooksMethod: SortNavdrawerNotebooksMethod = defaultOf(),
     val backupStrategy: BackupStrategy = defaultOf(),
     val noteDeletionTime: NoteDeletionTime = defaultOf(),
     val dateFormat: DateFormat = defaultOf(),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -48,6 +48,20 @@ enum class SortMethod(override val nameResource: Int) : HasNameResource, EnumPre
     MODIFIED_DESC(R.string.preferences_sort_method_modified_desc) { override val isDefault = true },
 }
 
+enum class SortTagsMethod(override val nameResource: Int) : HasNameResource, EnumPreference by key("sort_tags_method") {
+    TITLE_ASC(R.string.preferences_sort_method_title_asc),
+    TITLE_DESC(R.string.preferences_sort_method_title_desc),
+    CREATION_ASC(R.string.preferences_sort_method_created_asc),
+    CREATION_DESC(R.string.preferences_sort_method_created_desc),
+}
+
+enum class SortNavdrawerNotebooksMethod(override val nameResource: Int) : HasNameResource, EnumPreference by key("sort_navdrawer_notebooks_method") {
+    TITLE_ASC(R.string.preferences_sort_method_title_asc),
+    TITLE_DESC(R.string.preferences_sort_method_title_desc),
+    CREATION_ASC(R.string.preferences_sort_method_created_asc),
+    CREATION_DESC(R.string.preferences_sort_method_created_desc),
+}
+
 enum class BackupStrategy(override val nameResource: Int) : HasNameResource, EnumPreference by key("backup_strategy") {
     INCLUDE_FILES(R.string.preferences_backup_strategy_include_files) { override val isDefault = true },
     KEEP_INFO(R.string.preferences_backup_strategy_keep_info),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -38,6 +38,8 @@ class PreferenceRepository(
                     darkThemeMode = prefs.getEnum(),
                     colorScheme = prefs.getEnum(),
                     sortMethod = prefs.getEnum(),
+                    sortTagsMethod = prefs.getEnum(),
+                    sortNavdrawerNotebooksMethod = prefs.getEnum(),
                     backupStrategy = prefs.getEnum(),
                     noteDeletionTime = prefs.getEnum(),
                     dateFormat = prefs.getEnum(),

--- a/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
@@ -31,6 +31,7 @@ import org.qosp.notes.preferences.LayoutMode
 import org.qosp.notes.preferences.NoteDeletionTime
 import org.qosp.notes.preferences.PreferenceRepository
 import org.qosp.notes.preferences.SortMethod
+import org.qosp.notes.preferences.SortTagsMethod
 import org.qosp.notes.ui.reminders.ReminderManager
 import java.time.Instant
 import javax.inject.Inject
@@ -234,6 +235,12 @@ class ActivityViewModel @Inject constructor(
     }
 
     fun setSortMethod(method: SortMethod) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferenceRepository.set(method)
+        }
+    }
+
+    fun setSortTagsMethod(method: SortTagsMethod) {
         viewModelScope.launch(Dispatchers.IO) {
             preferenceRepository.set(method)
         }

--- a/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
@@ -31,6 +31,7 @@ import org.qosp.notes.preferences.LayoutMode
 import org.qosp.notes.preferences.NoteDeletionTime
 import org.qosp.notes.preferences.PreferenceRepository
 import org.qosp.notes.preferences.SortMethod
+import org.qosp.notes.preferences.SortNavdrawerNotebooksMethod
 import org.qosp.notes.preferences.SortTagsMethod
 import org.qosp.notes.ui.reminders.ReminderManager
 import java.time.Instant
@@ -241,6 +242,12 @@ class ActivityViewModel @Inject constructor(
     }
 
     fun setSortTagsMethod(method: SortTagsMethod) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferenceRepository.set(method)
+        }
+    }
+
+    fun setSortNavdrawerNotebooksMethod(method: SortNavdrawerNotebooksMethod) {
         viewModelScope.launch(Dispatchers.IO) {
             preferenceRepository.set(method)
         }

--- a/app/src/main/java/org/qosp/notes/ui/MainActivity.kt
+++ b/app/src/main/java/org/qosp/notes/ui/MainActivity.kt
@@ -218,23 +218,20 @@ class MainActivity : BaseActivity() {
 
             // Obtaining the current setting of notebook sorting order.
             val sort = runBlocking {
-                return@runBlocking async {
-                    preferenceRepository
-                        .getAll()
-                        .map { it.sortNavdrawerNotebooksMethod }
-                        .first()
-                        .name
-                }.await()
+                return@runBlocking preferenceRepository
+                    .getAll()
+                    .map { it.sortNavdrawerNotebooksMethod }
+                    .first()
+                    .name
             }
 
             // Sorting the notebooks.
-            var sortedNotebooks: List<Notebook>
-            when (sort) {
-                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.id }
-                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.id }
-                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.name }
-                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.name }
-                else -> sortedNotebooks = notebooks.sortedBy { it.name }
+            val sortedNotebooks: List<Notebook> = when (sort) {
+                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> notebooks.sortedBy { it.id }
+                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> notebooks.sortedByDescending { it.id }
+                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> notebooks.sortedBy { it.name }
+                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> notebooks.sortedByDescending { it.name }
+                else -> notebooks.sortedBy { it.name }
             }
 
             // Displaying the notebooks.

--- a/app/src/main/java/org/qosp/notes/ui/attachments/recycler/AttachmentsPreviewGridManager.kt
+++ b/app/src/main/java/org/qosp/notes/ui/attachments/recycler/AttachmentsPreviewGridManager.kt
@@ -10,7 +10,7 @@ class AttachmentsPreviewGridManager(private val context: Context, private val sp
     private var itemSpans = listOf<Int>()
 
     init {
-        spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+        spanSizeLookup = object : SpanSizeLookup() {
             override fun getSpanSize(position: Int) = itemSpans.getOrNull(position) ?: 1
         }
     }

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -987,11 +987,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         }
 
         actionAddTask.setOnClickListener {
-            var addTaskIndex = tasksAdapter.tasks.size;
+            var addTaskIndex = tasksAdapter.tasks.size
             if (model.moveCheckedItems)
-                addTaskIndex = tasksAdapter.tasks.indexOfLast { !it.isDone } + 1;
+                addTaskIndex = tasksAdapter.tasks.indexOfLast { !it.isDone } + 1
 
-            addTask(addTaskIndex);
+            addTask(addTaskIndex)
         }
     }
 

--- a/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
@@ -29,6 +29,7 @@ import org.qosp.notes.databinding.FragmentMainBinding
 import org.qosp.notes.databinding.LayoutNoteBinding
 import org.qosp.notes.preferences.LayoutMode
 import org.qosp.notes.preferences.SortMethod
+import org.qosp.notes.preferences.SortTagsMethod
 import org.qosp.notes.ui.attachments.fromUri
 import org.qosp.notes.ui.common.AbstractNotesFragment
 import org.qosp.notes.ui.recorder.RECORDED_ATTACHMENT

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksFragment.kt
@@ -163,13 +163,12 @@ class ManageNotebooksFragment : BaseFragment(R.layout.fragment_manage_notebooks)
 
         activityModel.notebooks.collect(viewLifecycleOwner) { (_, notebooks) ->
             // Apply sorting to the list of notebooks.
-            var sortedNotebooks: List<Notebook>
-            when (sort) {
-                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.name }
-                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.name }
-                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.id }
-                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.id }
-                else -> sortedNotebooks = notebooks.sortedBy { it.name }
+            val sortedNotebooks: List<Notebook> = when (sort) {
+                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> notebooks.sortedBy { it.name }
+                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> notebooks.sortedByDescending { it.name }
+                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> notebooks.sortedBy { it.id }
+                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> notebooks.sortedByDescending { it.id }
+                else -> notebooks.sortedBy { it.name }
             }
 
             // Displaying the sorted list of notebooks in the view.

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksFragment.kt
@@ -14,7 +14,10 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import org.qosp.notes.R
+import org.qosp.notes.data.model.Notebook
 import org.qosp.notes.databinding.FragmentManageNotebooksBinding
+import org.qosp.notes.preferences.SortNavdrawerNotebooksMethod
+import org.qosp.notes.preferences.SortTagsMethod
 import org.qosp.notes.ui.common.BaseFragment
 import org.qosp.notes.ui.common.recycler.onBackPressedHandler
 import org.qosp.notes.ui.notebooks.dialog.EditNotebookDialog
@@ -30,6 +33,8 @@ import org.qosp.notes.ui.utils.views.BottomSheet
 class ManageNotebooksFragment : BaseFragment(R.layout.fragment_manage_notebooks) {
     private val binding by viewBinding(FragmentManageNotebooksBinding::bind)
 
+    protected var mainMenu: Menu? = null
+
     private val model: ManageNotebooksViewModel by viewModels()
     private lateinit var adapter: NotebooksRecyclerAdapter
 
@@ -43,9 +48,7 @@ class ManageNotebooksFragment : BaseFragment(R.layout.fragment_manage_notebooks)
 
         setupRecyclerView()
 
-        activityModel.notebooks.collect(viewLifecycleOwner) { (_, notebooks) ->
-            adapter.submitList(notebooks)
-        }
+        enlistNotebooks()
 
         binding.layoutAppBar.toolbarSelection.apply {
             inflateMenu(R.menu.manage_notebooks_selected)
@@ -63,13 +66,21 @@ class ManageNotebooksFragment : BaseFragment(R.layout.fragment_manage_notebooks)
     @Deprecated("Deprecated in Java")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.manage_notebooks, menu)
+        mainMenu = menu
+        selectSortMethodItem()
     }
 
     @Deprecated("Deprecated in Java")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_create_notebook -> EditNotebookDialog.build(null).show(childFragmentManager, null)
+            R.id.action_sort_navdrawer_notebook_created_asc -> activityModel.setSortNavdrawerNotebooksMethod(SortNavdrawerNotebooksMethod.CREATION_ASC)
+            R.id.action_sort_navdrawer_notebook_created_desc -> activityModel.setSortNavdrawerNotebooksMethod(SortNavdrawerNotebooksMethod.CREATION_DESC)
+            R.id.action_sort_navdrawer_notebook_name_asc -> activityModel.setSortNavdrawerNotebooksMethod(SortNavdrawerNotebooksMethod.TITLE_ASC)
+            R.id.action_sort_navdrawer_notebook_name_desc -> activityModel.setSortNavdrawerNotebooksMethod(SortNavdrawerNotebooksMethod.TITLE_DESC)
         }
+        enlistNotebooks()
+        selectSortMethodItem()
         return super.onOptionsItemSelected(item)
     }
 
@@ -144,5 +155,37 @@ class ManageNotebooksFragment : BaseFragment(R.layout.fragment_manage_notebooks)
             binding.layoutAppBar.appBar,
             requireContext().resources.getDimension(R.dimen.app_bar_elevation)
         )
+    }
+
+    private fun enlistNotebooks() {
+        // Get the current sort method preferences.
+        val sort = model.getSortNavdrawerNotebooksMethod()
+
+        activityModel.notebooks.collect(viewLifecycleOwner) { (_, notebooks) ->
+            // Apply sorting to the list of notebooks.
+            var sortedNotebooks: List<Notebook>
+            when (sort) {
+                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.name }
+                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.name }
+                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> sortedNotebooks = notebooks.sortedBy { it.id }
+                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> sortedNotebooks = notebooks.sortedByDescending { it.id }
+                else -> sortedNotebooks = notebooks.sortedBy { it.name }
+            }
+
+            // Displaying the sorted list of notebooks in the view.
+            adapter.submitList(sortedNotebooks)
+        }
+    }
+
+    private fun selectSortMethodItem() {
+        mainMenu?.findItem(
+            when (model.getSortNavdrawerNotebooksMethod()) {
+                SortNavdrawerNotebooksMethod.TITLE_ASC.name -> R.id.action_sort_navdrawer_notebook_name_asc
+                SortNavdrawerNotebooksMethod.TITLE_DESC.name -> R.id.action_sort_navdrawer_notebook_name_desc
+                SortNavdrawerNotebooksMethod.CREATION_ASC.name -> R.id.action_sort_navdrawer_notebook_created_asc
+                SortNavdrawerNotebooksMethod.CREATION_DESC.name -> R.id.action_sort_navdrawer_notebook_created_desc
+                else -> R.id.action_sort_navdrawer_notebook_name_asc
+            }
+        )?.isChecked = true
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksViewModel.kt
@@ -27,13 +27,11 @@ class ManageNotebooksViewModel @Inject constructor(
 
     fun getSortNavdrawerNotebooksMethod() : String {
         return runBlocking {
-            return@runBlocking async {
-                preferenceRepository
-                    .getAll()
-                    .map { it.sortNavdrawerNotebooksMethod }
-                    .first()
-                    .name
-            }.await()
+            return@runBlocking preferenceRepository
+                .getAll()
+                .map { it.sortNavdrawerNotebooksMethod }
+                .first()
+                .name
         }
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/ManageNotebooksViewModel.kt
@@ -4,16 +4,36 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.qosp.notes.data.model.Notebook
 import org.qosp.notes.data.repo.NotebookRepository
+import org.qosp.notes.preferences.PreferenceRepository
 import javax.inject.Inject
 
 @HiltViewModel
-class ManageNotebooksViewModel @Inject constructor(private val notebookRepository: NotebookRepository) : ViewModel() {
+class ManageNotebooksViewModel @Inject constructor(
+    private val notebookRepository: NotebookRepository,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
     fun deleteNotebooks(vararg notebooks: Notebook) {
         viewModelScope.launch(Dispatchers.IO) {
             notebookRepository.delete(*notebooks)
+        }
+    }
+
+    fun getSortNavdrawerNotebooksMethod() : String {
+        return runBlocking {
+            return@runBlocking async {
+                preferenceRepository
+                    .getAll()
+                    .map { it.sortNavdrawerNotebooksMethod }
+                    .first()
+                    .name
+            }.await()
         }
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/NotebookFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/NotebookFragment.kt
@@ -13,7 +13,7 @@ class NotebookFragment : MainFragment() {
     override val currentDestinationId: Int = R.id.fragment_notebook
     private val args: NotebookFragmentArgs by navArgs()
 
-    override val notebookId: Long
+    override val notebookId: Long?
         get() = args.notebookId.takeIf { it >= 0L || it == R.id.nav_default_notebook.toLong() }
     override val toolbarTitle: String
         get() = args.notebookName

--- a/app/src/main/java/org/qosp/notes/ui/notebooks/NotebookFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/notebooks/NotebookFragment.kt
@@ -13,7 +13,7 @@ class NotebookFragment : MainFragment() {
     override val currentDestinationId: Int = R.id.fragment_notebook
     private val args: NotebookFragmentArgs by navArgs()
 
-    override val notebookId: Long?
+    override val notebookId: Long
         get() = args.notebookId.takeIf { it >= 0L || it == R.id.nav_default_notebook.toLong() }
     override val toolbarTitle: String
         get() = args.notebookName

--- a/app/src/main/java/org/qosp/notes/ui/recorder/RecordAudioDialog.kt
+++ b/app/src/main/java/org/qosp/notes/ui/recorder/RecordAudioDialog.kt
@@ -32,7 +32,7 @@ const val RECORD_CODE = "RECORD"
 const val RECORDED_ATTACHMENT = "RECORDED_ATTACHMENT"
 
 @AndroidEntryPoint
-class RecordAudioDialog() : BaseDialog<DialogRecordAudioBinding>() {
+class RecordAudioDialog : BaseDialog<DialogRecordAudioBinding>() {
     private var recorderService: RecorderServiceBinder? = null
     private var isPermissionGranted = false
 

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -45,6 +45,8 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupDarkThemeModeListener()
         setupLayoutModeListener()
         setupSortMethodListener()
+        setupSortTagsMethodListener()
+        setupSortNavdrawerMethodListener()
         setupGroupNotesWithoutNotebookListener()
         setupMoveCheckedItemsListener()
         setupOpenMediaInListener()
@@ -90,7 +92,8 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
                     }
                 )
                 binding.settingSortMethod.subText = getString(sortMethod.nameResource)
-                binding.settingSortMethod.subText = getString(sortMethod.nameResource)
+                binding.settingSortTagsMethod.subText = getString(sortTagsMethod.nameResource)
+                binding.settingSortNavdrawerMethod.subText = getString(sortNavdrawerNotebooksMethod.nameResource)
                 binding.settingBackupStrategy.subText = getString(backupStrategy.nameResource)
                 binding.settingOpenMedia.subText = getString(openMediaIn.nameResource)
                 binding.settingNoteDeletion.subText = getString(noteDeletionTime.nameResource)
@@ -156,6 +159,20 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
 
     private fun setupSortMethodListener() = binding.settingSortMethod.setOnClickListener {
         showPreferenceDialog(R.string.preferences_sort_method, appPreferences.sortMethod) { selected ->
+            model.setPreference(selected)
+        }
+    }
+
+    /* Changes the sorting method of tags list. */
+    private fun setupSortTagsMethodListener() = binding.settingSortTagsMethod.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_sort_tags_method, appPreferences.sortTagsMethod) { selected ->
+            model.setPreference(selected)
+        }
+    }
+
+    /* Changes the sorting method of notebooks list in the navigation drawer. */
+    private fun setupSortNavdrawerMethodListener() = binding.settingSortNavdrawerMethod.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_sort_navdrawer_method, appPreferences.sortNavdrawerNotebooksMethod) { selected ->
             model.setPreference(selected)
         }
     }

--- a/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
@@ -36,18 +36,6 @@ class TagsViewModel @Inject constructor(
     private val preferenceRepository: PreferenceRepository
 ) : ViewModel() {
 
-    lateinit var tagDataList: Flow<List<TagData>>
-
-    @CallSuper
-    open fun onTagDataListChanged(tagDataList: Flow<List<TagData>>) {
-        this.tagDataList = tagDataList
-
-        // Update the tag order
-        onSortMethodChanged()
-    }
-
-    open fun onSortMethodChanged() {}
-
     fun getData(noteId: Long? = null): Flow<List<TagData>> {
         return when (noteId) {
             null -> tagRepository.getAll().map { tags ->

--- a/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
@@ -50,17 +50,12 @@ class TagsViewModel @Inject constructor(
     }
 
     fun getSortTagsMethod() : String {
-
         return runBlocking {
-            val sort = async {
-                preferenceRepository
-                    .getAll()
-                    .map { it.sortTagsMethod }
-                    .first()
-                    .name
-            }
-
-            return@runBlocking sort.await()
+            return@runBlocking preferenceRepository
+                .getAll()
+                .map { it.sortTagsMethod }
+                .first()
+                .name
         }
     }
 

--- a/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/tags/TagsViewModel.kt
@@ -1,22 +1,52 @@
 package org.qosp.notes.ui.tags
 
+import android.util.Log
+import androidx.annotation.CallSuper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import me.msoul.datastore.defaultOf
+import org.qosp.notes.data.model.Note
 import org.qosp.notes.data.model.Tag
 import org.qosp.notes.data.repo.TagRepository
+import org.qosp.notes.preferences.AppPreferences
+import org.qosp.notes.preferences.LayoutMode
+import org.qosp.notes.preferences.PreferenceRepository
+import org.qosp.notes.preferences.SortTagsMethod
 import javax.inject.Inject
 
 data class TagData(val tag: Tag, val inNote: Boolean)
 
 @HiltViewModel
-class TagsViewModel @Inject constructor(private val tagRepository: TagRepository) : ViewModel() {
+class TagsViewModel @Inject constructor(
+    private val tagRepository: TagRepository,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
+
+    lateinit var tagDataList: Flow<List<TagData>>
+
+    @CallSuper
+    open fun onTagDataListChanged(tagDataList: Flow<List<TagData>>) {
+        this.tagDataList = tagDataList
+
+        // Update the tag order
+        onSortMethodChanged()
+    }
+
+    open fun onSortMethodChanged() {}
 
     fun getData(noteId: Long? = null): Flow<List<TagData>> {
         return when (noteId) {
@@ -28,6 +58,21 @@ class TagsViewModel @Inject constructor(private val tagRepository: TagRepository
                     tags.map { TagData(it, it in noteTags) }
                 }
             }
+        }
+    }
+
+    fun getSortTagsMethod() : String {
+
+        return runBlocking {
+            val sort = async {
+                preferenceRepository
+                    .getAll()
+                    .map { it.sortTagsMethod }
+                    .first()
+                    .name
+            }
+
+            return@runBlocking sort.await()
         }
     }
 
@@ -54,4 +99,10 @@ class TagsViewModel @Inject constructor(private val tagRepository: TagRepository
             tagRepository.deleteTagFromNote(tagId, noteId)
         }
     }
+
+    data class TagDataList(
+        val tagsList: MutableList<TagData> = mutableListOf(),
+        val sortTagsMethod: SortTagsMethod = defaultOf()
+    )
+
 }

--- a/app/src/main/java/org/qosp/notes/ui/utils/coil/CoilImagesPlugin.kt
+++ b/app/src/main/java/org/qosp/notes/ui/utils/coil/CoilImagesPlugin.kt
@@ -53,7 +53,7 @@ class CoilImagesPlugin internal constructor(coilStore: CoilStore, imageLoader: I
         AsyncDrawableScheduler.schedule(textView)
     }
 
-    private class CoilAsyncDrawableLoader internal constructor(
+    private class CoilAsyncDrawableLoader(
         private val coilStore: CoilStore,
         private val imageLoader: ImageLoader,
     ) :

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -143,10 +143,42 @@
                     app:text="@string/preferences_time_format"
                     app:iconSrc="@drawable/ic_time"/>
 
+            <!-- Tags -->
+            <TextView
+                android:text="@string/preferences_header_view_tags"
+                android:fontFamily="@font/inter_font_family"
+                android:textColor="?attr/colorSecondary"
+                android:padding="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
+                android:id="@+id/setting_sort_tags_method"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/preferences_sort_tags_method"
+                app:iconSrc="@drawable/ic_sort"/>
+
+            <!-- Navigation drawer -->
+            <TextView
+                android:text="@string/preferences_header_view_navdrawer"
+                android:fontFamily="@font/inter_font_family"
+                android:textColor="?attr/colorSecondary"
+                android:padding="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
+                android:id="@+id/setting_sort_navdrawer_method"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/preferences_sort_navdrawer_method"
+                app:iconSrc="@drawable/ic_sort"/>
+
             <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="?attr/colorOutline"/>
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorOutline"/>
 
             <!-- Other -->
             <TextView

--- a/app/src/main/res/menu/manage_notebooks.xml
+++ b/app/src/main/res/menu/manage_notebooks.xml
@@ -2,6 +2,29 @@
 <menu
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:title="@string/preferences_sort_method"
+        android:icon="@drawable/ic_sort"
+        app:showAsAction="ifRoom">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/action_sort_navdrawer_notebook_name_asc"
+                    android:title="@string/preferences_sort_method_title_asc"/>
+                <item
+                    android:id="@+id/action_sort_navdrawer_notebook_name_desc"
+                    android:title="@string/preferences_sort_method_title_desc"/>
+                <item
+                    android:id="@+id/action_sort_navdrawer_notebook_created_asc"
+                    android:title="@string/preferences_sort_method_created_asc"/>
+                <item
+                    android:id="@+id/action_sort_navdrawer_notebook_created_desc"
+                    android:title="@string/preferences_sort_method_created_desc"/>
+            </group>
+        </menu>
+    </item>
+
     <item
             android:id="@+id/action_create_notebook"
             android:title="@string/action_create_notebook"

--- a/app/src/main/res/menu/tags.xml
+++ b/app/src/main/res/menu/tags.xml
@@ -1,6 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:title="@string/preferences_sort_method"
+        android:icon="@drawable/ic_sort"
+        app:showAsAction="ifRoom">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/action_sort_tags_name_asc"
+                    android:title="@string/preferences_sort_method_title_asc"/>
+                <item
+                    android:id="@+id/action_sort_tags_name_desc"
+                    android:title="@string/preferences_sort_method_title_desc"/>
+                <item
+                    android:id="@+id/action_sort_tags_created_asc"
+                    android:title="@string/preferences_sort_method_created_asc"/>
+                <item
+                    android:id="@+id/action_sort_tags_created_desc"
+                    android:title="@string/preferences_sort_method_created_desc"/>
+            </group>
+        </menu>
+    </item>
+
     <item
             android:id="@+id/action_create_tag"
             android:title="@string/action_new_tag"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,6 +313,10 @@
     <string name="shortcut_take_note">Take a note</string>
     <string name="shortcut_make_list">Make a list</string>
     <string name="never">Never</string>
+    <string name="preferences_header_view_tags">Tag list</string>
+    <string name="preferences_sort_tags_method">Sort tags by</string>
+    <string name="preferences_header_view_navdrawer">Navigation drawer</string>
+    <string name="preferences_sort_navdrawer_method">Sort notebooks by</string>
 
     <plurals name="more_items">
         <item quantity="one">+%d item</item>


### PR DESCRIPTION
In this PR, I establish sorting functionality in notebook list as well as tag list. This PR might resolve #44, #77, and #184.

Highlights
-

First of all, I created two new settings context in the `AppPreference`: tag list sorting and navigation drawer's notebook sorting. (As seen in the attached screenshot.)

Next, I created the back-end to sort notebooks and tags by: alphabetical and creation date order (both ascending and descending). And since ****Quillnote**/Quillpad** does not yet store tag nor notebook creation date in the JSON schema, I use `tagId` and `notebookId` order to determine "creation date" order.

Finally, I added sorter button in both the "Manage Notebooks" menu and the tag list, so that the user does not need to open app's configuration in order to change sorting.

Contribution
-

This PR fulfills two-years-old issues inquiring notebook and tag sorting feature in **Quillpad.** (#44, #77, and #184)

Caveat
-

- It seems that the user needs to click the sort button twice (or open another menu) in order to view the updated list after sorting the "Manage Notebooks" menu and tag list. I could not figure out how to force re-render the `ViewModel` after data sorting.
- Notebook list in the navigation drawer needs app restart before sorting can be displayed. This is because the navigation drawer is hardcoded to render its UI only during launch in earlier versions.

Preview
-

![image1](https://github.com/user-attachments/assets/55a624a0-1d55-477b-ace1-758b5e789bc2)