### PR TITLE
Add Note to Nextcloud sync settings that Nextcloud Notes need to be installes on the Server

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -77,7 +77,7 @@
     <string name="preferences_cloud_service_disabled">Deaktiviert</string>
     <string name="preferences_cloud_service_nextcloud">Nextcloud</string>
     <string name="preferences_sync_experimental_warning">Synchronisierung is aktuell experimentell.\nEs können Fehler auftreten.</string>
-    <string name="preferences_nextcloud_limited_features">Aktuell unterstützt Nextcloud Notes keine Tags, Anhänge, Erinnerungen und weitere Funktionen.</string>
+    <string name="preferences_nextcloud_limited_features">Aktuell unterstützt Nextcloud Notes keine Tags, Anhänge, Erinnerungen und weitere Funktionen. Nextcloud Notes muss auf dem Nextcloud Server installiert sein, sonnst scheitert die Anmeldung mit "Es ist ein Problem aufgetreten."!</string>
     <string name="preferences_nextcloud_account">Nextcloud Konto</string>
     <string name="preferences_nextcloud_instance_url">URL der Nextcloud Instanz</string>
     <string name="preferences_nextcloud_set_your_credentials">Zugangsdaten einstellen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,7 @@
     <string name="preferences_cloud_service_disabled">Disabled</string>
     <string name="preferences_cloud_service_nextcloud">Nextcloud</string>
     <string name="preferences_sync_experimental_warning">Syncing functionality is currently experimental.\nYou may encounter bugs.</string>
-    <string name="preferences_nextcloud_limited_features">Keep in mind Nextcloud Notes does not support features such as tags, attachments, reminders and more.</string>
+    <string name="preferences_nextcloud_limited_features">Keep in mind Nextcloud Notes does not support features such as tags, attachments, reminders and more. Nextcloud Notes need to be installed on the Nextcloud Server or the Login will fail with "Something went wrong"!</string>
     <string name="preferences_nextcloud_account">Nextcloud account</string>
     <string name="preferences_nextcloud_instance_url">Nextcloud instance URL</string>
     <string name="preferences_nextcloud_set_your_credentials">Set your credentials</string>


### PR DESCRIPTION
I had problems and spend a lot of time trying to get nextcloud sync working. I eventually found out that nextcloud notes need to be installed on the server and to improve the experience for other I've added this note: "Nextcloud Notes need to be installed on the Nextcloud Server or the Login will fail with "Something went wrong"!"