### PR TITLE
Add option to remove all checked tasks

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -443,6 +443,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                     true
                 }
 
+                R.id.action_remove_all_checked_tasks -> {
+                    removeAllCheckedTasks()
+                    true
+                }
+
                 else -> false
             }
         }
@@ -730,6 +735,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         }
 
         findItem(R.id.action_uncheck_all_tasks)?.apply {
+            isVisible = note.isList && !note.isDeleted
+        }
+
+        findItem(R.id.action_remove_all_checked_tasks)?.apply {
             isVisible = note.isList && !note.isDeleted
         }
     }
@@ -1210,6 +1219,15 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     private fun uncheckAllTasks() {
         val updatedTasks = tasksAdapter.tasks.map { task ->
             task.copy(isDone = false)
+        }
+        tasksAdapter.submitList(updatedTasks)
+
+        model.updateTaskList(updatedTasks)
+    }
+
+    private fun removeAllCheckedTasks() {
+        val updatedTasks = tasksAdapter.tasks.filter { task ->
+            !task.isDone
         }
         tasksAdapter.submitList(updatedTasks)
 

--- a/app/src/main/res/menu/editor_top.xml
+++ b/app/src/main/res/menu/editor_top.xml
@@ -49,6 +49,11 @@
         android:visible="true"
         app:showAsAction="ifRoom"/>
     <item
+        android:id="@+id/action_remove_all_checked_tasks"
+        android:title="@string/action_remove_all_checked_tasks"
+        android:visible="true"
+        app:showAsAction="ifRoom"/>
+    <item
             android:id="@+id/action_delete_note"
             android:title="@string/action_delete"
             android:visible="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,7 @@
     <string name="action_insert_quote">Insert quotation markdown</string>
     <string name="action_insert_code">Insert code markdown</string>
     <string name="action_uncheck_all_tasks">Uncheck all items</string>
+    <string name="action_remove_all_checked_tasks">Remove all checked tasks</string>
     <string name="indicator_note_date">Created at %1$s\nLast modified at %2$s</string>
     <string name="indicator_restored_notes">Restored notes</string>
     <string name="indicator_restored_note">Restored note</string>


### PR DESCRIPTION
This PR adds an option to the task menu which removes all tasks which have been checked.

This would close #160 and #329. Maybe #375 too, they mention #329 as a "similar issue", but I am not sure if it fits their use case or not.

Tell me if there is any problem with the implementation and I will gladly address it.

Great app, many thanks for maintaining it!
