### PR TITLE
Use the note title as a fallback for the reminder title

### DIFF
--- a/app/src/androidTest/java/org/qosp/notes/di/TestUtilModule.kt
+++ b/app/src/androidTest/java/org/qosp/notes/di/TestUtilModule.kt
@@ -43,7 +43,8 @@ object TestUtilModule {
     fun provideReminderManager(
         @ApplicationContext context: Context,
         reminderRepository: ReminderRepository,
-    ) = ReminderManager(context, reminderRepository)
+        noteRepository: NoteRepository,
+    ) = ReminderManager(context, reminderRepository, noteRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/org/qosp/notes/di/UtilModule.kt
+++ b/app/src/main/java/org/qosp/notes/di/UtilModule.kt
@@ -39,7 +39,8 @@ object UtilModule {
     fun provideReminderManager(
         @ApplicationContext context: Context,
         reminderRepository: ReminderRepository,
-    ) = ReminderManager(context, reminderRepository)
+        noteRepository: NoteRepository,
+    ) = ReminderManager(context, reminderRepository, noteRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/org/qosp/notes/ui/reminders/ReminderManager.kt
+++ b/app/src/main/java/org/qosp/notes/ui/reminders/ReminderManager.kt
@@ -14,10 +14,12 @@ import kotlinx.coroutines.flow.first
 import org.qosp.notes.App
 import org.qosp.notes.R
 import org.qosp.notes.data.repo.ReminderRepository
+import org.qosp.notes.data.repo.NoteRepository
 
 class ReminderManager(
     private val context: Context,
     private val reminderRepository: ReminderRepository,
+    private val noteRepository: NoteRepository,
 ) {
     private fun requestBroadcast(reminderId: Long, noteId: Long, flag: Int = PendingIntent.FLAG_UPDATE_CURRENT): PendingIntent? {
         val defaultFlag = PendingIntent.FLAG_IMMUTABLE
@@ -90,6 +92,10 @@ class ReminderManager(
 
         reminderRepository.getById(reminderId).first()?.let { notificationTitle = it.name }
         reminderRepository.deleteById(reminderId)
+
+        if (notificationTitle.isEmpty()) {
+            noteRepository.getById(noteId).first()?.let { notificationTitle = it.title }
+        }
 
         val pendingIntent = NavDeepLinkBuilder(context)
             .setGraph(R.navigation.nav_graph)


### PR DESCRIPTION
Currently, if there is no reminder title, the notification won't show any thing to help locate what it is about (can't open the note on my devices), and the bell icon and scheduled date time in the note are also cleaned up.

I'd like to suggest use the note title instead, if no reminder title. It is a easy fallback, and practical.
* Normally, the reminder is most likely with the same title. Repeat inputting isn't necessary.
* There is a default note title. People will change it to be meaningful if the note is important.

It's a kind of workaround for https://github.com/quillpad/quillpad/issues/87.

PS:
Don't know why, but the following doesn't work on my devices (Android 8 and 15). I'll try to do some research.
https://github.com/quillpad/quillpad/blob/5f7c84b20e32e6feadb68bd463aa0c8377bff61d/app/src/main/java/org/qosp/notes/ui/reminders/ReminderManager.kt#L94-L103