### PR TITLE
Add support for shared media attachments

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,11 +16,47 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:launchMode="singleTask">
+            <!-- Handle shared text -->
             <intent-filter android:label="@string/shortcut_take_note">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!-- Handle single media sharing -->
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
+            <!-- Handle multiple media sharing -->
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/shortcut_take_note">
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/app/src/main/java/org/qosp/notes/components/MediaStorageManager.kt
+++ b/app/src/main/java/org/qosp/notes/components/MediaStorageManager.kt
@@ -59,6 +59,7 @@ class MediaStorageManager(
                 val prefix = when (type) {
                     MediaType.IMAGE -> "img_"
                     MediaType.AUDIO -> "audio_"
+                    MediaType.VIDEO -> "video_"
                 }
 
                 val file = File.createTempFile(prefix, extension, directory)
@@ -68,6 +69,8 @@ class MediaStorageManager(
     }
 
     enum class MediaType(val defaultExtension: String) {
-        IMAGE(".jpg"), AUDIO(".mp3");
+        IMAGE(".jpg"),
+        VIDEO(".mp4"),
+        AUDIO(".mp3")
     }
 }


### PR DESCRIPTION
The ability to share media from other apps is a feature I (and some others https://github.com/quillpad/quillpad/issues/352) would like to have. This change adds support to share single or multiple image, video or audio files to the app.

I'm not an Android dev, so I apologise in advance for any obvious mistakes, or if this is the wrong way to achieve this.  I hacked this together (with the help of GH copilot in full disclosure) and it seems to be functional.

Let me know if this is something your're interested in adding.
I'm happy to rework, or let someone who knows what they're doing do it correctly. 

Thanks for this awesome app!