### PR TITLE
Fix note synchronization when a remote note is deleted.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,7 @@ max_line_length = 120
 # ij_wrap_on_typing = false
 
 [*.xml]
-ij_continuation_indent_size = 4
+# ij_continuation_indent_size = 4
 ij_xml_align_attributes = true
 # ij_xml_align_text = false
 # ij_xml_attribute_wrap = normal
@@ -42,7 +42,7 @@ ij_xml_keep_blank_lines = 2
 # ij_xml_space_after_tag_name = false
 # ij_xml_space_around_equals_in_attribute = false
 # ij_xml_space_inside_empty_tag = true
-ij_xml_text_wrap = normal
+ij_xml_text_wrap = off
 # ij_xml_use_custom_settings = true
 
 [{*.kt,*.kts}]

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.quillpad"
         minSdk = 24
         targetSdk = 35
-        versionCode = 44
-        versionName = "1.5.2"
+        versionCode = 45
+        versionName = "1.5.3"
 
         testInstrumentationRunner = "org.qosp.notes.TestRunner"
 

--- a/app/src/main/java/org/qosp/notes/data/repo/NoteRepository.kt
+++ b/app/src/main/java/org/qosp/notes/data/repo/NoteRepository.kt
@@ -11,7 +11,7 @@ import org.qosp.notes.preferences.SortMethod
 interface NoteRepository {
     suspend fun insertNote(note: Note, sync: Boolean = true): Long
     suspend fun updateNotes(vararg notes: Note, sync: Boolean = true)
-    suspend fun moveNotesToBin(vararg notes: Note)
+    suspend fun moveNotesToBin(vararg notes: Note, sync: Boolean = true)
     suspend fun restoreNotes(vararg notes: Note)
     suspend fun deleteNotes(vararg notes: Note, sync: Boolean = true)
     suspend fun discardEmptyNotes(): Boolean

--- a/app/src/main/java/org/qosp/notes/data/sync/core/SynchronizeNotes.kt
+++ b/app/src/main/java/org/qosp/notes/data/sync/core/SynchronizeNotes.kt
@@ -67,7 +67,7 @@ class SynchronizeNotes(private val idMappingRepository: IdMappingRepository) {
                             }
                             // If equal, no action needed
                         } else {
-                            // Remote note doesn't exist, create it with empty ID
+                            // Remote note doesn't exist
                             // This happens when the remote note was deleted
                             val syncNote = SyncNote(
                                 title = localNote.title,
@@ -77,7 +77,7 @@ class SynchronizeNotes(private val idMappingRepository: IdMappingRepository) {
                                 id = 0,
                             )
                             logDebug("May be deleted remotely: $syncNote")
-                            remoteUpdates.add(NoteAction.Create(localNote, syncNote))
+                            localUpdates.add(NoteAction.Delete(localNote, syncNote))
                         }
 
                     } else {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -323,8 +323,6 @@
     <string name="what_is_new">ما الجديد؟</string>
     <string name="continue_next">متابعة</string>
     <string name="swipe_to_find_out_whats_new">اسحب لمعرفة ما الجديد</string>
-    <string name="what_is_new_content" translatable="false">"ميزة مثيرة: يمكنك الآن حفظ الملاحظات كملفات في مجلد. يمكنك الوصول إلى هذه الميزة عن طريق اختيار المزامنة -> تخزين الملفات في الإعدادات."
-    </string>
 
     <plurals name="more_items">
         <item quantity="zero">+%d عناصر</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,7 +324,8 @@
     <string name="what_is_new">What\'s new?</string>
     <string name="continue_next">Continue</string>
     <string name="swipe_to_find_out_whats_new">Swipe through to find out what\'s new</string>
-    <string name="what_is_new_content" translatable="false">New error reporting feature via email for better support
+    <string name="what_is_new_content"
+            translatable="false">"New Feature: Report errors and crashes via email\nFix: Deleting a file remotely re-creates the file on sync\n "
     </string>
 
     <plurals name="more_items">

--- a/app/src/test/java/org/qosp/notes/data/sync/core/SynchronizeNotesTest.kt
+++ b/app/src/test/java/org/qosp/notes/data/sync/core/SynchronizeNotesTest.kt
@@ -171,9 +171,9 @@ class SynchronizeNotesTest {
     }
 
     @Test
-    fun `deleted remote note should delete local note mapping`() = runTest {
+    fun `deleted remote note should trigger local delete action`() = runTest {
         // Given
-        val localNote = Note(id = 1L, title = "Local Note", modifiedDate = 100L)
+        val localNote = Note(id = 1L, title = "Local Note", modifiedDate = 100L, content = "Some content")
         val mapping = IdMapping(
             localNoteId = 1L,
             remoteNoteId = 2L,
@@ -188,11 +188,15 @@ class SynchronizeNotesTest {
         val result = synchronizeNotes(listOf(localNote), emptyList(), CloudService.NEXTCLOUD)
 
         // Then
-        assertEquals(0, result.localUpdates.size)
-        assertEquals(1, result.remoteUpdates.size)
-        val action = result.remoteUpdates[0] as NoteAction.Create
+        assertEquals(1, result.localUpdates.size)
+        assertEquals(0, result.remoteUpdates.size)
+        val action = result.localUpdates[0] as NoteAction.Delete
         assertEquals(localNote, action.note)
+        // Check that the remoteNote in the action is a placeholder, as the actual remote note is gone
         assertEquals("", action.remoteNote.idStr)
+        assertEquals(localNote.title, action.remoteNote.title)
+        assertEquals(localNote.modifiedDate, action.remoteNote.lastModified)
+        assertEquals(localNote.content, action.remoteNote.content)
     }
 
     @Test


### PR DESCRIPTION
This commit addresses an issue where deleting a note on the remote server was incorrectly handled. Previously, the app would attempt to re-create the note remotely.

The fix ensures that if a local note has a corresponding remote mapping but the remote note is not found, a local delete action is triggered instead. This correctly reflects the remote deletion by moving the local note to the bin and removing its remote ID mapping.

Fixes #487