### PR TITLE
Cleanup unused ID mapping in repositories

### DIFF
--- a/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
+++ b/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
@@ -169,7 +169,6 @@ class NoteRepositoryImpl(
 
         noteDao.update(*entities)
         reminderDao.deleteIfNoteIdIn(notes.map { it.id })
-        idMappingDao.deleteByLocalId(*notes.map { it.id }.toLongArray())
         cleanMappingsForLocalNotes(*notes)
         notes.filterNot { it.isLocalOnly }.forEach {
             if (sync) processRemoteActions(it.id, Delete(it))

--- a/app/src/main/java/org/qosp/notes/data/sync/core/BackendProvider.kt
+++ b/app/src/main/java/org/qosp/notes/data/sync/core/BackendProvider.kt
@@ -27,19 +27,19 @@ class BackendProvider(
 ) {
     private val syncService: Flow<CloudService> = preferenceRepository.getAll().map { it.cloudService }
     private val pref: StateFlow<AppPreferences?> =
-        preferenceRepository.getAll().stateIn(syncingScope, SharingStarted.Companion.Eagerly, null)
+        preferenceRepository.getAll().stateIn(syncingScope, SharingStarted.Eagerly, null)
 
     val syncProvider: StateFlow<ISyncBackend?> = combine(
         syncService,
-        NextcloudConfig.Companion.fromPreferences(preferenceRepository),
-        StorageConfig.Companion.storageLocation(preferenceRepository)
+        NextcloudConfig.fromPreferences(preferenceRepository),
+        StorageConfig.storageLocation(preferenceRepository)
     ) { service, nextcloudConfig, storageConfig ->
         when (service) {
             CloudService.DISABLED -> null
             CloudService.NEXTCLOUD -> nextcloudConfig?.let { NextcloudBackend(nextcloudApiProvider, it) }
             CloudService.FILE_STORAGE -> storageConfig?.let { StorageBackend(context, it) }
         }
-    }.stateIn(syncingScope, SharingStarted.Companion.Eagerly, null)
+    }.stateIn(syncingScope, SharingStarted.Eagerly, null)
 
     val isSyncing: Boolean
         get() = syncProvider.value != null && connectionManager.isConnectionAvailable(


### PR DESCRIPTION
- Remove unnecessary `idMappingDao.deleteByLocalId` call in note repository logic.
- Fixes #495