### PR TITLE
Add support for updating note extras in ID mapping

### DIFF
--- a/app/src/main/java/org/qosp/notes/data/dao/IdMappingDao.kt
+++ b/app/src/main/java/org/qosp/notes/data/dao/IdMappingDao.kt
@@ -16,6 +16,9 @@ interface IdMappingDao {
     @Update
     suspend fun update(vararg mappings: IdMapping)
 
+    @Query("UPDATE cloud_ids SET extras = :extras WHERE localNoteId = :localId AND provider = :cloudService")
+    suspend fun updateNoteExtras(localId: Long, cloudService: CloudService, extras: String?)
+
     @Query("DELETE FROM cloud_ids WHERE localNoteId IN (:ids)")
     suspend fun deleteByLocalId(vararg ids: Long)
 

--- a/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
+++ b/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
@@ -105,6 +105,11 @@ class NoteRepositoryImpl(
                         } else {
                             localNote.copy(id = action.note.id)
                         }
+                        idMappingDao.updateNoteExtras(
+                            localId = action.note.id,
+                            cloudService = syncProvider.type,
+                            extras = action.remoteNote.extra
+                        )
                         updateNote(note, sync = false)
                     }
 


### PR DESCRIPTION
- The issue was when a remote note is updated, its ETag is updated too. The corresponding extra needs to be updated in local as well. Failure to do so will not update the remote note using the old ETag.
- Fixes #498