### PR TITLE
Feat: Add default editor mode setting

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
@@ -20,6 +20,7 @@ data class AppPreferences(
     val showFabChangeMode: ShowFabChangeMode = defaultOf(),
     val groupNotesWithoutNotebook: GroupNotesWithoutNotebook = defaultOf(),
     val moveCheckedItems: MoveCheckedItems = defaultOf(),
+    val defaultEditorMode: DefaultEditorMode = defaultOf(),
     val cloudService: CloudService = defaultOf(),
     val syncMode: SyncMode = defaultOf(),
     val backgroundSync: BackgroundSync = defaultOf(),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -139,6 +139,13 @@ enum class MoveCheckedItems(
     NO(R.string.no),
 }
 
+enum class DefaultEditorMode(
+    override val nameResource: Int
+) : HasNameResource, EnumPreference by key("default_editor_mode") {
+    VIEW(R.string.preferences_default_editor_mode_view) { override val isDefault = true },
+    EDIT(R.string.preferences_default_editor_mode_edit)
+}
+
 enum class CloudService(override val nameResource: Int) : HasNameResource, EnumPreference by key("cloud_service") {
     DISABLED(R.string.preferences_cloud_service_disabled) { override val isDefault = true },
     NEXTCLOUD(R.string.preferences_cloud_service_nextcloud),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -50,6 +50,7 @@ class PreferenceRepository(
                     showFabChangeMode = prefs.getEnum(),
                     groupNotesWithoutNotebook = prefs.getEnum(),
                     moveCheckedItems = prefs.getEnum(),
+                    defaultEditorMode = prefs.getEnum(),
                     cloudService = prefs.getEnum(),
                     syncMode = prefs.getEnum(),
                     backgroundSync = prefs.getEnum(),

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -58,6 +58,7 @@ import io.noties.markwon.editor.MarkwonEditorTextWatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.commonmark.node.Code
+import org.qosp.notes.preferences.DefaultEditorMode
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.qosp.notes.R
@@ -793,6 +794,10 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             // Update Title and Content only the first the since they are EditTexts
             if (isFirstLoad) {
 
+                if (data.defaultEditorMode == DefaultEditorMode.EDIT) {
+                    model.inEditMode = true
+                }
+
                 // apply font size preference
                 if (data.editorFontSize != -1) { // is customised
                     val fontSizeFloat = data.editorFontSize.toFloat()
@@ -1196,7 +1201,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     /** Gives the focus to the note body if it is empty */
     private fun requestFocusForFields(forceFocus: Boolean = false) = with(binding) {
-        if (editTextContent.text.isNullOrEmpty() || forceFocus) {
+        if (data.note?.isEmpty() == true || forceFocus) {
             editTextContent.requestFocusAndKeyboard()
         }
     }

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.msoul.datastore.defaultOf
+import org.qosp.notes.preferences.DefaultEditorMode
 import org.qosp.notes.data.model.Attachment
 import org.qosp.notes.data.model.Note
 import org.qosp.notes.data.model.NoteColor
@@ -61,6 +62,7 @@ class EditorViewModel(
                         showDates = prefs.showDate == ShowDate.YES,
                         editorFontSize = prefs.editorFontSize.fontSize,
                         showFabChangeMode = prefs.showFabChangeMode == ShowFabChangeMode.FAB,
+                        defaultEditorMode = prefs.defaultEditorMode,
                         isInitialized = true,
                     )
                 }
@@ -185,6 +187,7 @@ class EditorViewModel(
         val showDates: Boolean = true,
         val editorFontSize: Int = -1, // -1: not customised, default font size
         val showFabChangeMode: Boolean = true,
+        val defaultEditorMode: DefaultEditorMode = defaultOf(),
         val isInitialized: Boolean = false,
         val moveCheckedItems: Boolean = true,
     )

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -63,6 +63,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupShowDateListener()
         setupShowFontSizeListener()
         setupShowFabChangeModeListener()
+        setupDefaultEditorModeListener()
         setupDateFormatListener()
         setupTimeFormatListener()
         setupSyncSettingsListener()
@@ -108,6 +109,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
                 binding.settingShowDate.subText = getString(showDate.nameResource)
                 binding.settingFontSize.subText = getString(editorFontSize.nameResource)
                 binding.settingShowFab.subText = getString(showFabChangeMode.nameResource)
+                binding.settingDefaultEditorMode.subText = getString(defaultEditorMode.nameResource)
                 with(DateTimeFormatter.ofPattern(getString(dateFormat.patternResource))) {
                     binding.settingDateFormat.subText = format(LocalDate.now())
                 }
@@ -234,6 +236,12 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
 
     private fun setupShowFabChangeModeListener() = binding.settingShowFab.setOnClickListener {
         showPreferenceDialog(R.string.preferences_show_fab_change_mode, appPreferences.showFabChangeMode) { selected ->
+            model.setPreference(selected)
+        }
+    }
+
+    private fun setupDefaultEditorModeListener() = binding.settingDefaultEditorMode.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_default_editor_mode, appPreferences.defaultEditorMode) { selected ->
             model.setPreference(selected)
         }
     }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -123,6 +123,13 @@
                 app:iconSrc="@drawable/ic_pencil"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
+                android:id="@+id/setting_default_editor_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/preferences_default_editor_mode"
+                app:iconSrc="@drawable/ic_pencil"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_show_date"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,9 @@
     <string name="preferences_fab">Floating button</string>
     <string name="preferences_top_bar">Top bar</string>
 
+    <string name="preferences_default_editor_mode">Default editor mode</string>
+    <string name="preferences_default_editor_mode_view">View mode</string>
+    <string name="preferences_default_editor_mode_edit">Edit mode</string>
     <string name="preferences_show_date">Show date created/modified</string>
     <string name="preferences_date_format">Date format</string>
     <string name="preferences_time_format">Time format</string>


### PR DESCRIPTION
Adds a default editor mode setting, which can be either view mode (default) or edit mode.
This setting changes the default editor mode when opening a note. With view mode as default, the current behavior is unchanged. With edit mode, users will no longer have to press the mode toggle button before they can edit the note.

Closes https://github.com/quillpad/quillpad/issues/221 and possibly https://github.com/quillpad/quillpad/issues/143#issuecomment-1554079775.