### PR TITLE
Fix Android app shortcuts not available

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,9 +58,6 @@
                 <data android:mimeType="audio/*" />
             </intent-filter>
 
-            <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".ui.launcher.LauncherActivity"
@@ -69,6 +66,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity android:name="org.qosp.notes.ui.media.MediaActivity" />


### PR DESCRIPTION
## Description

android.app.shortcuts metadata was on MainActivity, but Android expects shortcuts to be on the LauncherActivity

Fixes issue #420

In version 1.4.28 (https://github.com/quillpad/quillpad/commit/40a78eac50637aaace87a27d2e12b5c6f90fe84e), the MAIN/LAUNCHER entry point was moved to LauncherActivity, but the shortcuts were still pointing to MainActivity. Android app shortcuts should be associated with the MAIN/LAUNCHER
[reference](https://developer.android.com/develop/ui/views/launch/shortcuts/creating-shortcuts#static) 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Cleanup
- [ ] Translation / Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project (we use `.editorconfig`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
