### PR TITLE
fix: prevent backup corruption by using Reader for JSON deserialization

### DIFF
--- a/app/src/main/java/org/qosp/notes/components/backup/BackupManager.kt
+++ b/app/src/main/java/org/qosp/notes/components/backup/BackupManager.kt
@@ -169,10 +169,11 @@ class BackupManager(
                 when (entry.name) {
                     "backup.json" -> {
                         // Create backup class
+                        val reader = input.reader()
                         val builder = StringBuilder()
-                        val buffer = ByteArray(BUFFER)
+                        val buffer = CharArray(BUFFER)
                         var length = 0
-                        while (input.read(buffer).also { length = it } > 0) {
+                        while (reader.read(buffer).also { length = it } > 0) {
                             builder.append(String(buffer, 0, length))
                         }
                         val deserialized = migrationHandler.migrate(builder.toString())


### PR DESCRIPTION
## Description
This PR fixes a bug in the backup restoration logic where backup.json could become corrupted during the reading process.The previous implementation read raw bytes into a ByteArray and converted them to a String in chunks. If a multi-byte character (like an emoji or a special symbol in UTF-8) was split across two buffer reads, it resulted in invalid character decoding and corrupted JSON.By switching to input.reader() and a CharArray buffer, the logic now correctly handles character boundaries, ensuring that backups containing special characters are restored safely.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Cleanup
- [ ] Translation / Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project (we use `.editorconfig`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

Fixes #73 