### PR TITLE
Add image picker to Markdown image dialog

### DIFF
--- a/app/src/main/java/org/qosp/notes/components/MediaStorageManager.kt
+++ b/app/src/main/java/org/qosp/notes/components/MediaStorageManager.kt
@@ -2,10 +2,15 @@ package org.qosp.notes.components
 
 import android.content.Context
 import android.net.Uri
+import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
+import org.commonmark.node.AbstractVisitor
+import org.commonmark.node.Image
+import org.commonmark.parser.Parser
 import org.qosp.notes.BuildConfig
 import org.qosp.notes.data.repo.NoteRepository
 import org.qosp.notes.ui.attachments.getAttachmentUri
@@ -31,11 +36,14 @@ class MediaStorageManager(
     }
 
     suspend fun cleanUpStorage() = runCatching {
-        val filesUsed = noteRepository
+        val notes = noteRepository
             .getAll()
             .first()
-            .flatMap { it.attachments }
-            .map { it.path }
+        val filesUsed = notes
+            .flatMap { note ->
+                note.attachments.map { it.path } + note.content.markdownImageDestinations()
+            }
+            .toSet()
 
         val files = directory
             .list()
@@ -46,6 +54,45 @@ class MediaStorageManager(
                 File(directory, file).delete()
             }
         }
+    }
+
+    suspend fun copyMediaToPrivateStorage(uri: Uri, mimeType: String): Uri? = withContext(Dispatchers.IO) {
+        val mediaType = when {
+            mimeType.startsWith("image/") -> MediaType.IMAGE
+            mimeType.startsWith("video/") -> MediaType.VIDEO
+            mimeType.startsWith("audio/") -> MediaType.AUDIO
+            else -> return@withContext null
+        }
+
+        val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)?.let { ".$it" }
+            ?: mediaType.defaultExtension
+        val (newUri, file) = createMediaFile(mediaType, extension) ?: return@withContext null
+
+        val copied = try {
+            val input = context.contentResolver.openInputStream(uri)
+            if (input == null) {
+                file.delete()
+                return@withContext null
+            }
+            input.use { source ->
+                file.outputStream().use { target ->
+                    source.copyTo(target)
+                }
+            }
+            true
+        } catch (error: CancellationException) {
+            file.delete()
+            throw error
+        } catch (error: Exception) {
+            false
+        }
+
+        if (!copied) {
+            file.delete()
+            return@withContext null
+        }
+
+        newUri
     }
 
     /***
@@ -72,5 +119,22 @@ class MediaStorageManager(
         IMAGE(".jpg"),
         VIDEO(".mp4"),
         AUDIO(".mp3")
+    }
+
+    private fun String.markdownImageDestinations(): List<String> {
+        if (!contains("![")) return emptyList()
+
+        val destinations = mutableListOf<String>()
+        Parser.builder()
+            .build()
+            .parse(this)
+            .accept(object : AbstractVisitor() {
+                override fun visit(image: Image) {
+                    image.destination?.let(destinations::add)
+                    visitChildren(image)
+                }
+            })
+
+        return destinations
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/ActivityViewModel.kt
@@ -1,7 +1,6 @@
 package org.qosp.notes.ui
 
 import android.net.Uri
-import android.webkit.MimeTypeMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
@@ -15,7 +14,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.msoul.datastore.defaultOf
 import org.qosp.notes.components.MediaStorageManager
 import org.qosp.notes.data.model.Note
@@ -183,25 +181,8 @@ class ActivityViewModel(
         return uri
     }
 
-    /**
-     * Creates a file for the shared media in app's private storage
-     * @param uri The source URI of the media file
-     * @param mimeType The MIME type of the media
-     * @return The new URI in app's private storage, or null if creation failed
-     */
-    suspend fun copyMediaToPrivateStorage(uri: Uri, mimeType: String): Uri? = withContext(Dispatchers.IO) {
-        val mediaType = when {
-            mimeType.startsWith("image/") -> MediaStorageManager.MediaType.IMAGE
-            mimeType.startsWith("video/") -> MediaStorageManager.MediaType.VIDEO
-            mimeType.startsWith("audio/") -> MediaStorageManager.MediaType.AUDIO
-            else -> return@withContext null
-        }
-
-        val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)?.let { ".$it" }
-            ?: mediaType.defaultExtension
-
-        mediaStorageManager.createMediaFile(mediaType, extension)?.first
-    }
+    suspend fun copyMediaToPrivateStorage(uri: Uri, mimeType: String): Uri? =
+        mediaStorageManager.copyMediaToPrivateStorage(uri, mimeType)
 
     private inline fun update(
         vararg notes: Note,

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -23,6 +23,8 @@ import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
 import androidx.activity.addCallback
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -82,6 +84,7 @@ import org.qosp.notes.ui.editor.dialog.InsertImageDialog
 import org.qosp.notes.ui.editor.dialog.InsertTableDialog
 import org.qosp.notes.ui.editor.markdown.MarkdownSpan
 import org.qosp.notes.ui.editor.markdown.applyTo
+import org.qosp.notes.ui.editor.markdown.imageMarkdown
 import org.qosp.notes.ui.editor.markdown.insertMarkdown
 import org.qosp.notes.ui.editor.markdown.toggleCheckmarkCurrentLine
 import org.qosp.notes.ui.media.MediaActivity
@@ -137,6 +140,8 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     private var isList: Boolean = false
     private var isFirstLoad: Boolean = true
     private var formatter: DateTimeFormatter? = null
+    private var pendingImageDescription: String = ""
+    private var pendingImageSelection: Pair<Int, Int>? = null
 
     private lateinit var attachmentsAdapter: AttachmentsAdapter
     private lateinit var tasksAdapter: TasksAdapter
@@ -166,6 +171,30 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         model.insertAttachments(Attachment.fromUri(requireContext(), uri))
         activityModel.tempPhotoUri = null
+    }
+
+    private val pickImageForMarkdownLauncher = registerForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        val description = pendingImageDescription
+        val selection = pendingImageSelection
+        pendingImageDescription = ""
+        pendingImageSelection = null
+        if (uri == null || view == null) return@registerForActivityResult
+
+        val mimeType = context?.contentResolver?.getType(uri) ?: "image/jpeg"
+        viewLifecycleOwner.lifecycleScope.launch {
+            val privateUri = activityModel.copyMediaToPrivateStorage(uri, mimeType)
+            if (!isAdded || view == null) return@launch
+
+            if (privateUri == null) {
+                Snackbar.make(binding.root, getString(R.string.message_image_copy_failed), Snackbar.LENGTH_SHORT)
+                    .show()
+                return@launch
+            }
+
+            insertMarkdownAtSelection(imageMarkdown(privateUri.toString(), description), selection)
+        }
     }
 
     private val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(UP or DOWN, LEFT or RIGHT) {
@@ -328,12 +357,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         setFragmentResultListener(MARKDOWN_DIALOG_RESULT) { _, bundle ->
             val markdown = bundle.getString(MARKDOWN_DIALOG_RESULT) ?: return@setFragmentResultListener
-            binding.editTextContent.apply {
-                if (selectedText?.isNotEmpty() == true) {
-                    text?.replace(selectionStart, selectionEnd, "")
-                }
-                text?.insert(selectionStart, markdown)
-            }
+            insertMarkdownAtSelection(markdown)
+        }
+
+        setFragmentResultListener(IMAGE_PICKER_DIALOG_RESULT) { _, bundle ->
+            pickImageForMarkdown(bundle.getString(IMAGE_PICKER_DESCRIPTION).orEmpty())
         }
 
         binding.fabChangeMode.setOnClickListener {
@@ -969,6 +997,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
                 R.id.action_insert_image -> {
                     clearFragmentResult(MARKDOWN_DIALOG_RESULT)
+                    clearFragmentResult(IMAGE_PICKER_DIALOG_RESULT)
                     InsertImageDialog
                         .build(editTextContent.selectedText ?: "")
                         .show(parentFragmentManager, null)
@@ -1025,6 +1054,32 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             // Always add new tasks at the top (position 0)
             addTask(0)
         }
+    }
+
+    private fun insertMarkdownAtSelection(markdown: String, selection: Pair<Int, Int>? = null) = with(binding.editTextContent) {
+        val editable = text ?: return@with
+        val range = model.selectedRange
+        val rawStart = selection?.first ?: selectionStart.takeIf { it >= 0 } ?: range.first
+        val rawEnd = selection?.second ?: selectionEnd.takeIf { it >= 0 } ?: range.second
+        val start = minOf(rawStart, rawEnd).coerceIn(0, editable.length)
+        val end = maxOf(rawStart, rawEnd).coerceIn(0, editable.length)
+
+        if (end > start) {
+            editable.replace(start, end, "")
+        }
+        editable.insert(start, markdown)
+        setSelection((start + markdown.length).coerceAtMost(editable.length))
+    }
+
+    private fun pickImageForMarkdown(description: String) {
+        pendingImageDescription = description
+        pendingImageSelection = with(binding.editTextContent) { selectionStart to selectionEnd }
+        model.selectedRange = pendingImageSelection ?: model.selectedRange
+        pickImageForMarkdownLauncher.launch(
+            PickVisualMediaRequest.Builder()
+                .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                .build()
+        )
     }
 
     private fun setupMarkdown() {
@@ -1280,5 +1335,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
     companion object {
         const val MARKDOWN_DIALOG_RESULT = "MARKDOWN_DIALOG_RESULT"
+        const val IMAGE_PICKER_DIALOG_RESULT = "IMAGE_PICKER_DIALOG_RESULT"
+        const val IMAGE_PICKER_DESCRIPTION = "IMAGE_PICKER_DESCRIPTION"
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/editor/dialog/InsertImageDialog.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/dialog/InsertImageDialog.kt
@@ -30,7 +30,15 @@ class InsertImageDialog : BaseDialog<DialogInsertImageBinding>() {
 
         dialog.apply {
             setTitle(getString(R.string.action_insert_image))
-            setButton(AlertDialog.BUTTON_NEUTRAL, getString(R.string.action_cancel)) { _, _ -> }
+            setButton(AlertDialog.BUTTON_NEGATIVE, getString(R.string.action_cancel)) { _, _ -> }
+            setButton(AlertDialog.BUTTON_NEUTRAL, getString(R.string.action_choose_image)) { _, _ ->
+                setFragmentResult(
+                    EditorFragment.IMAGE_PICKER_DIALOG_RESULT,
+                    bundleOf(
+                        EditorFragment.IMAGE_PICKER_DESCRIPTION to binding.editTextImageDescription.text.toString()
+                    )
+                )
+            }
             setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.action_insert)) { _, _ ->
                 val markdown = imageMarkdown(
                     url = binding.editTextImagePath.text.toString(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,8 +282,10 @@
     <string name="action_insert_table">Insert table</string>
     <string name="message_invalid_number_rows_columns">Invalid number of rows and columns</string>
     <string name="action_insert_image">Insert image</string>
+    <string name="action_choose_image">Choose image</string>
     <string name="hint_image_description">Description</string>
     <string name="hint_image_path">Image path</string>
+    <string name="message_image_copy_failed">Could not copy the image.</string>
     <string name="hint_hyperlink_text">Text</string>
     <string name="hint_hyperlink_url">URL</string>
     <string name="hint_number_columns">Number of columns</string>


### PR DESCRIPTION
## Summary
- add a Choose image button to the Markdown image dialog
- copy selected media into the app private media directory before inserting Markdown
- keep Markdown-referenced private media during media cleanup

## Test
- .\\gradlew.bat :app:assembleDebug