### PR TITLE
Make editor bottom toolbar configurable

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -73,5 +73,6 @@ class PreferenceRepository(
         const val NEXTCLOUD_USERNAME = "NEXTCLOUD_USERNAME"
         const val NEXTCLOUD_PASSWORD = "NEXTCLOUD_PASSWORD"
         const val STORAGE_LOCATION = "STORAGE_LOCATION"
+        const val EDITOR_BOTTOM_TOOLBAR_CONFIG = "EDITOR_BOTTOM_TOOLBAR_CONFIG"
     }
 }

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorBottomToolbarConfig.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorBottomToolbarConfig.kt
@@ -1,0 +1,79 @@
+package org.qosp.notes.ui.editor
+
+import org.qosp.notes.R
+
+enum class EditorBottomToolbarItem(
+    val key: String,
+    val itemId: Int,
+    val titleRes: Int,
+    val iconRes: Int,
+) {
+    BOLD("bold", R.id.action_insert_bold, R.string.action_insert_bold_text, R.drawable.ic_bold),
+    ITALICS("italics", R.id.action_insert_italics, R.string.action_insert_italics, R.drawable.ic_italics),
+    STRIKETHROUGH(
+        "strikethrough",
+        R.id.action_insert_strikethrough,
+        R.string.action_insert_strikethrough,
+        R.drawable.ic_strikethrough,
+    ),
+    HEADING("heading", R.id.action_insert_heading, R.string.action_insert_heading, R.drawable.ic_header),
+    QUOTE("quote", R.id.action_insert_quote, R.string.action_insert_quote, R.drawable.ic_quote),
+    HIGHLIGHT("highlight", R.id.action_insert_highlight, R.string.action_insert_highlight, R.drawable.ic_highlight),
+    CODE("code", R.id.action_insert_code, R.string.action_insert_code, R.drawable.ic_code),
+    LINK("link", R.id.action_insert_link, R.string.action_insert_link, R.drawable.ic_link),
+    TABLE("table", R.id.action_insert_table, R.string.action_insert_table, R.drawable.ic_table),
+    IMAGE("image", R.id.action_insert_image, R.string.action_insert_image, R.drawable.ic_photo),
+    CHECK_LINE(
+        "check_line",
+        R.id.action_toggle_check_line,
+        R.string.action_toggle_check_line,
+        R.drawable.ic_box_checked_outline,
+    ),
+    SCROLL_TOP("scroll_top", R.id.action_scroll_to_top, R.string.action_scroll_to_top, R.drawable.ic_up),
+    SCROLL_BOTTOM("scroll_bottom", R.id.action_scroll_to_bottom, R.string.action_scroll_to_bottom, R.drawable.ic_down),
+    UNDO("undo", R.id.action_undo, R.string.action_undo, R.drawable.ic_undo),
+    REDO("redo", R.id.action_redo, R.string.action_redo, R.drawable.ic_redo),
+}
+
+data class EditorBottomToolbarItemState(
+    val item: EditorBottomToolbarItem,
+    val visible: Boolean,
+)
+
+object EditorBottomToolbarConfig {
+    val defaultItems: List<EditorBottomToolbarItemState>
+        get() = EditorBottomToolbarItem.entries.map { EditorBottomToolbarItemState(it, visible = true) }
+
+    fun parse(value: String): List<EditorBottomToolbarItemState> {
+        if (value.isBlank()) return defaultItems
+
+        val itemsByKey = EditorBottomToolbarItem.entries.associateBy { it.key }
+        val parsed = value.split(ITEM_SEPARATOR)
+            .mapNotNull { entry ->
+                val parts = entry.split(VALUE_SEPARATOR, limit = 2)
+                val item = itemsByKey[parts.getOrNull(0)] ?: return@mapNotNull null
+                EditorBottomToolbarItemState(
+                    item = item,
+                    visible = parts.getOrNull(1) != HIDDEN_VALUE,
+                )
+            }
+
+        val parsedItems = parsed.map { it.item }.toSet()
+        val missingItems = EditorBottomToolbarItem.entries
+            .filterNot { it in parsedItems }
+            .map { EditorBottomToolbarItemState(it, visible = true) }
+
+        return parsed + missingItems
+    }
+
+    fun serialize(items: List<EditorBottomToolbarItemState>): String {
+        return items.joinToString(ITEM_SEPARATOR) { state ->
+            "${state.item.key}$VALUE_SEPARATOR${if (state.visible) VISIBLE_VALUE else HIDDEN_VALUE}"
+        }
+    }
+
+    private const val ITEM_SEPARATOR = ","
+    private const val VALUE_SEPARATOR = ":"
+    private const val VISIBLE_VALUE = "1"
+    private const val HIDDEN_VALUE = "0"
+}

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -137,6 +137,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     private var isList: Boolean = false
     private var isFirstLoad: Boolean = true
     private var formatter: DateTimeFormatter? = null
+    private var appliedBottomToolbarItems: List<EditorBottomToolbarItemState> = emptyList()
 
     private lateinit var attachmentsAdapter: AttachmentsAdapter
     private lateinit var tasksAdapter: TasksAdapter
@@ -295,6 +296,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         data = Data()
         isFirstLoad = true
+        appliedBottomToolbarItems = emptyList()
 
         if (model.isNotInitialized) {
             model.initialize(
@@ -585,7 +587,8 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     private fun setMarkdownToolbarVisibility(note: Note? = data.note) = with(binding) {
         if (note == null) return@with
 
-        containerBottomToolbar.isVisible = !isList && note.isMarkdownEnabled && model.inEditMode && contentHasFocus
+        containerBottomToolbar.isVisible =
+            !isList && note.isMarkdownEnabled && model.inEditMode && contentHasFocus && bottomToolbar.menu.size() > 0
 
         scrollView.updateLayoutParams<ConstraintLayout.LayoutParams> {
             val actionBarSize = requireContext().getDimensionAttribute(R.attr.actionBarSize) ?: 0
@@ -594,6 +597,25 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
                 else -> 0
             }
         }
+    }
+
+    private fun applyBottomToolbarItems(items: List<EditorBottomToolbarItemState>) = with(binding.bottomToolbar.menu) {
+        if (items == appliedBottomToolbarItems) return@with
+        appliedBottomToolbarItems = items
+
+        clear()
+
+        items
+            .filter { it.visible }
+            .forEachIndexed { index, state ->
+                add(Menu.NONE, state.item.itemId, index, state.item.titleRes).apply {
+                    setIcon(state.item.iconRes)
+                    setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+                    if (itemId == R.id.action_undo || itemId == R.id.action_redo) {
+                        isEnabled = false
+                    }
+                }
+            }
     }
 
     private fun setupEditTexts() = with(binding) {
@@ -851,6 +873,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             }
             recyclerTasks.isVisible = isList
 
+            applyBottomToolbarItems(data.bottomToolbarItems)
             updateEditMode(note = data.note)
 
             // Must be called after updateEditMode since that method changes the visibility of the inputs

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -51,19 +52,23 @@ class EditorViewModel(
         .filterNotNull()
         .flatMapLatest { note ->
             getNotebookData(note.notebookId).flatMapLatest { notebook ->
-                preferenceRepository.getAll().map { prefs ->
-                    Data(
-                        note = note,
-                        notebook = notebook,
-                        dateTimeFormats = prefs.dateFormat to prefs.timeFormat,
-                        openMediaInternally = prefs.openMediaIn == OpenMediaIn.INTERNAL,
-                        showDates = prefs.showDate == ShowDate.YES,
-                        editorFontSize = prefs.editorFontSize.fontSize,
-                        showFabChangeMode = prefs.showFabChangeMode == ShowFabChangeMode.FAB,
-                        defaultEditorMode = prefs.defaultEditorMode,
-                        isInitialized = true,
-                    )
-                }
+                preferenceRepository.getAll()
+                    .combine(
+                        preferenceRepository.getEncryptedString(PreferenceRepository.EDITOR_BOTTOM_TOOLBAR_CONFIG)
+                    ) { prefs, toolbarConfig ->
+                        Data(
+                            note = note,
+                            notebook = notebook,
+                            dateTimeFormats = prefs.dateFormat to prefs.timeFormat,
+                            openMediaInternally = prefs.openMediaIn == OpenMediaIn.INTERNAL,
+                            showDates = prefs.showDate == ShowDate.YES,
+                            editorFontSize = prefs.editorFontSize.fontSize,
+                            showFabChangeMode = prefs.showFabChangeMode == ShowFabChangeMode.FAB,
+                            defaultEditorMode = prefs.defaultEditorMode,
+                            bottomToolbarItems = EditorBottomToolbarConfig.parse(toolbarConfig),
+                            isInitialized = true,
+                        )
+                    }
             }
         }
         .stateIn(
@@ -186,6 +191,7 @@ class EditorViewModel(
         val editorFontSize: Int = -1, // -1: not customised, default font size
         val showFabChangeMode: Boolean = true,
         val defaultEditorMode: DefaultEditorMode = defaultOf(),
+        val bottomToolbarItems: List<EditorBottomToolbarItemState> = EditorBottomToolbarConfig.defaultItems,
         val isInitialized: Boolean = false,
         val moveCheckedItems: Boolean = true,
     )

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -1,11 +1,21 @@
 package org.qosp.notes.ui.settings
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.widget.AppCompatCheckBox
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.qosp.notes.R
@@ -15,10 +25,13 @@ import org.qosp.notes.preferences.CloudService
 import org.qosp.notes.preferences.DarkThemeMode
 import org.qosp.notes.preferences.DateFormat
 import org.qosp.notes.preferences.LayoutMode
+import org.qosp.notes.preferences.PreferenceRepository
 import org.qosp.notes.preferences.ThemeMode
 import org.qosp.notes.preferences.TimeFormat
 import org.qosp.notes.ui.MainActivity
 import org.qosp.notes.ui.common.BaseFragment
+import org.qosp.notes.ui.editor.EditorBottomToolbarConfig
+import org.qosp.notes.ui.editor.EditorBottomToolbarItemState
 import org.qosp.notes.ui.utils.RestoreNotesContract
 import org.qosp.notes.ui.utils.collect
 import org.qosp.notes.ui.utils.liftAppBarOnScroll
@@ -57,6 +70,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupSortNavdrawerMethodListener()
         setupGroupNotesWithoutNotebookListener()
         setupMoveCheckedItemsListener()
+        setupEditBottomToolbarListener()
         setupOpenMediaInListener()
         setupNoteDeletionTimeListener()
         setupBackupStrategyListener()
@@ -210,10 +224,125 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         }
     }
 
+    private fun setupEditBottomToolbarListener() = binding.settingEditBottomToolbar.setOnClickListener {
+        lifecycleScope.launch {
+            val items = EditorBottomToolbarConfig
+                .parse(model.getEncryptedString(PreferenceRepository.EDITOR_BOTTOM_TOOLBAR_CONFIG).first())
+                .toMutableList()
+            showEditBottomToolbarDialog(items)
+        }
+    }
+
     private fun setupOpenMediaInListener() = binding.settingOpenMedia.setOnClickListener {
         showPreferenceDialog(R.string.preferences_open_media_in, appPreferences.openMediaIn) { selected ->
             model.setPreference(selected)
         }
+    }
+
+    private fun showEditBottomToolbarDialog(items: MutableList<EditorBottomToolbarItemState>) {
+        val content = LinearLayout(requireContext()).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, 8.dp, 0, 8.dp)
+        }
+
+        fun refreshRows() {
+            content.removeAllViews()
+            items.forEachIndexed { index, state ->
+                content.addView(createToolbarItemRow(items, index, state, ::refreshRows))
+            }
+        }
+
+        refreshRows()
+
+        val scrollView = ScrollView(requireContext()).apply {
+            addView(
+                content,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+            )
+        }
+
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.preferences_edit_bottom_toolbar)
+            .setView(scrollView)
+            .setNegativeButton(R.string.action_cancel, null)
+            .setNeutralButton(R.string.action_reset, null)
+            .setPositiveButton(R.string.action_done, null)
+            .create()
+
+        dialog.setOnShowListener {
+            dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                items.clear()
+                items.addAll(EditorBottomToolbarConfig.defaultItems)
+                refreshRows()
+            }
+            dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                model.setEncryptedString(
+                    PreferenceRepository.EDITOR_BOTTOM_TOOLBAR_CONFIG,
+                    EditorBottomToolbarConfig.serialize(items),
+                )
+                dialog.dismiss()
+            }
+        }
+
+        dialog.show()
+    }
+
+    private fun createToolbarItemRow(
+        items: MutableList<EditorBottomToolbarItemState>,
+        index: Int,
+        state: EditorBottomToolbarItemState,
+        refreshRows: () -> Unit,
+    ): View {
+        val row = LinearLayout(requireContext()).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(16.dp, 6.dp, 8.dp, 6.dp)
+        }
+
+        val checkbox = AppCompatCheckBox(requireContext()).apply {
+            isChecked = state.visible
+            setOnCheckedChangeListener { _, isChecked ->
+                items[index] = items[index].copy(visible = isChecked)
+            }
+        }
+
+        val icon = AppCompatImageView(requireContext()).apply {
+            setImageResource(state.item.iconRes)
+            layoutParams = LinearLayout.LayoutParams(32.dp, 32.dp).apply {
+                marginEnd = 12.dp
+            }
+        }
+
+        val label = AppCompatTextView(requireContext()).apply {
+            text = getString(state.item.titleRes)
+            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        }
+
+        val upButton = AppCompatImageButton(requireContext()).apply {
+            setImageResource(R.drawable.ic_up)
+            contentDescription = getString(R.string.action_move_up)
+            isEnabled = index > 0
+            setOnClickListener {
+                java.util.Collections.swap(items, index, index - 1)
+                refreshRows()
+            }
+        }
+
+        val downButton = AppCompatImageButton(requireContext()).apply {
+            setImageResource(R.drawable.ic_down)
+            contentDescription = getString(R.string.action_move_down)
+            isEnabled = index < items.lastIndex
+            setOnClickListener {
+                java.util.Collections.swap(items, index, index + 1)
+                refreshRows()
+            }
+        }
+
+        listOf(checkbox, icon, label, upButton, downButton).forEach(row::addView)
+        return row
     }
 
     private fun setupNoteDeletionTimeListener() = binding.settingNoteDeletion.setOnClickListener {
@@ -271,4 +400,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
             model.setPreference(selected)
         }
     }
+
+    private val Int.dp: Int
+        get() = (this * resources.displayMetrics.density).toInt()
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -198,6 +198,14 @@
                     android:layout_height="wrap_content"/>
 
                 <org.qosp.notes.ui.utils.views.PreferenceView
+                    android:id="@+id/setting_edit_bottom_toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:text="@string/preferences_edit_bottom_toolbar"
+                    app:subText="@string/preferences_edit_bottom_toolbar_subtext"
+                    app:iconSrc="@drawable/ic_markdown"/>
+
+                <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_open_media"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/menu/editor_bottom.xml
+++ b/app/src/main/res/menu/editor_bottom.xml
@@ -53,29 +53,29 @@
             app:showAsAction="always"/>
     <item
             android:id="@+id/action_toggle_check_line"
-            android:title=""
+            android:title="@string/action_toggle_check_line"
             android:icon="@drawable/ic_box_checked_outline"
             app:showAsAction="always"/>
     <item
             android:id="@+id/action_scroll_to_top"
             android:icon="@drawable/ic_up"
             app:showAsAction="always"
-            android:title=""/>
+            android:title="@string/action_scroll_to_top"/>
     <item
             android:id="@+id/action_scroll_to_bottom"
             android:icon="@drawable/ic_down"
             app:showAsAction="always"
-            android:title=""/>
+            android:title="@string/action_scroll_to_bottom"/>
     <item
             android:id="@+id/action_undo"
             android:icon="@drawable/ic_undo"
             app:showAsAction="always"
             android:enabled="false"
-            android:title=""/>
+            android:title="@string/action_undo"/>
     <item
             android:id="@+id/action_redo"
             android:icon="@drawable/ic_redo"
             app:showAsAction="always"
             android:enabled="false"
-            android:title=""/>
+            android:title="@string/action_redo"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,9 @@
     <!-- Preferences / Other -->
     <string name="preferences_header_other">Other</string>
 
+    <string name="preferences_edit_bottom_toolbar">Edit bottom toolbar</string>
+    <string name="preferences_edit_bottom_toolbar_subtext">Choose tools and order</string>
+
     <string name="preferences_open_media_in">Open media in</string>
     <string name="preferences_open_media_in_internal">Internal player</string>
     <string name="preferences_open_media_in_external">External player</string>
@@ -159,6 +162,7 @@
     <string name="hint_password">Password</string>
     <string name="action_save">Save</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_reset">Reset</string>
     <string name="action_delete">Delete</string>
     <string name="action_done">Done!</string>
     <string name="action_delete_permanently">Delete permanently</string>
@@ -175,6 +179,8 @@
     <string name="action_unpin">Unpin</string>
     <string name="action_restore">Restore</string>
     <string name="action_share">Share</string>
+    <string name="action_move_up">Move up</string>
+    <string name="action_move_down">Move down</string>
     <string name="action_pin_unpin">Pin / Unpin</string>
     <string name="action_move_to">Move to…</string>
     <string name="action_duplicate">Duplicate</string>
@@ -267,6 +273,11 @@
     <string name="action_insert_heading">Insert heading markdown</string>
     <string name="action_insert_quote">Insert quotation markdown</string>
     <string name="action_insert_code">Insert code markdown</string>
+    <string name="action_toggle_check_line">Toggle checklist item</string>
+    <string name="action_scroll_to_top">Scroll to top</string>
+    <string name="action_scroll_to_bottom">Scroll to bottom</string>
+    <string name="action_undo">Undo</string>
+    <string name="action_redo">Redo</string>
     <string name="action_uncheck_all_tasks">Uncheck all items</string>
     <string name="action_remove_all_checked_tasks">Remove all checked tasks</string>
     <string name="indicator_note_date">Created at %1$s\nLast modified at %2$s</string>


### PR DESCRIPTION
## Summary
- add a setting to choose editor bottom toolbar buttons and order
- persist toolbar configuration using app preferences
- rebuild the Markdown toolbar from saved configuration

## Test
- .\gradlew.bat :app:assembleDebug