### PR TITLE
Add Monet color scheme presets

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -42,6 +42,10 @@ enum class ColorScheme(
             return Build.VERSION.SDK_INT >= 31
         }
     },
+    MONET_WATER_LILIES(R.string.preferences_color_scheme_monet_water_lilies, R.style.MonetWaterLilies),
+    MONET_SUNRISE(R.string.preferences_color_scheme_monet_sunrise, R.style.MonetSunrise),
+    MONET_GARDEN(R.string.preferences_color_scheme_monet_garden, R.style.MonetGarden),
+    MONET_IRIS(R.string.preferences_color_scheme_monet_iris, R.style.MonetIris),
 }
 
 enum class SortMethod(override val nameResource: Int) : HasNameResource, EnumPreference by key("sort_method") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,10 @@
     <string name="preferences_color_scheme_brown">Brown</string>
     <string name="preferences_color_scheme_gray">Gray</string>
     <string name="preferences_color_scheme_system">Follow system</string>
+    <string name="preferences_color_scheme_monet_water_lilies">Monet: Water Lilies</string>
+    <string name="preferences_color_scheme_monet_sunrise">Monet: Sunrise</string>
+    <string name="preferences_color_scheme_monet_garden">Monet: Garden</string>
+    <string name="preferences_color_scheme_monet_iris">Monet: Iris</string>
 
     <!-- Preferences / View -->
     <string name="preferences_header_view">View</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -143,4 +143,44 @@
         <item name="colorPrimaryTranscluent">#29673AB7</item>
 
     </style>
+
+    <style name="MonetWaterLilies">
+        <item name="colorPrimary">#6A8FA6</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="colorSecondary">#7CA6A1</item>
+
+        <item name="colorDrawerHeaderBackground">#996A8FA6</item>
+        <item name="colorPrimaryTranscluent">#336A8FA6</item>
+
+    </style>
+
+    <style name="MonetSunrise">
+        <item name="colorPrimary">#E59A7A</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="colorSecondary">#D4B36F</item>
+
+        <item name="colorDrawerHeaderBackground">#99E59A7A</item>
+        <item name="colorPrimaryTranscluent">#33E59A7A</item>
+
+    </style>
+
+    <style name="MonetGarden">
+        <item name="colorPrimary">#7FA37D</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="colorSecondary">#B5A26A</item>
+
+        <item name="colorDrawerHeaderBackground">#997FA37D</item>
+        <item name="colorPrimaryTranscluent">#337FA37D</item>
+
+    </style>
+
+    <style name="MonetIris">
+        <item name="colorPrimary">#8D7DB8</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="colorSecondary">#A794C7</item>
+
+        <item name="colorDrawerHeaderBackground">#998D7DB8</item>
+        <item name="colorPrimaryTranscluent">#338D7DB8</item>
+
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- add four Monet-inspired app color scheme presets
- register the new presets in the color scheme preference enum
- add theme resources and labels for each preset

## Test
- .\gradlew.bat :app:assembleDebug