### PR TITLE
Fix: IllegalArgumentException when checking/swiping focused checklist items

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -180,6 +180,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         override fun getSwipeVelocityThreshold(defaultValue: Float) = defaultValue / 3
 
         override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+            binding.scrollView.findFocus()?.clearFocus()
             tasksAdapter.tasks.removeAt(viewHolder.bindingAdapterPosition)
             model.updateTaskList(tasksAdapter.tasks)
             tasksAdapter.notifyItemRemoved(viewHolder.bindingAdapterPosition)
@@ -1124,6 +1125,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
         tasks[position] = newTask
 
         if (oldTask.isDone != newTask.isDone && model.moveCheckedItems) {
+            binding.scrollView.findFocus()?.clearFocus()
             if (newTask.isDone) {
                 // Move to very end
                 tasks.removeAt(position)
@@ -1243,6 +1245,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     }
 
     private fun uncheckAllTasks() {
+        binding.scrollView.findFocus()?.clearFocus()
         val updatedTasks = tasksAdapter.tasks.map { task ->
             task.copy(isDone = false)
         }
@@ -1252,6 +1255,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
     }
 
     private fun removeAllCheckedTasks() {
+        binding.scrollView.findFocus()?.clearFocus()
         val updatedTasks = tasksAdapter.tasks.filter { task ->
             !task.isDone
         }


### PR DESCRIPTION
This PR fixes a frequent crash when using the checklist mode in the editor.
The Problem: When a user is editing a task and either checks it off (triggering a move to the bottom) or swipes it away, the app crashes with: `java.lang.IllegalArgumentException: parameter must be a descendant of this view at android.view.ViewGroup.offsetRectBetweenParentAndChild`.

This is a known issue when NestedScrollView contains a RecyclerView. If a child view has focus and the RecyclerView detaches or moves that view (via notifyItemMoved or notifyItemRemoved), NestedScrollView still attempts to calculate its position during the layout phase to keep it in view. Since the view is no longer a descendant at that specific moment, the app crashes.

The Solution: I added `binding.scrollView.findFocus()?.clearFocus()` before any operations that significantly change the RecyclerView layout while items might be focused:

- In updateTask() when an item is moved.
- In onSwiped() when an item is deleted.
- In batch operations like uncheckAllTasks() and removeAllCheckedTasks().

Clearing the focus ensures that NestedScrollView doesn't attempt the invalid coordinate calculation during the adapter update.

Steps to reproduce the crash (before fix):

1. Create a checklist.
2. Ensure "Move checked items to bottom" is enabled in settings.
3. Click into a task to focus the keyboard.
4. Click the checkbox of that same focused task.
5. -> Crash.

Tested on:

- Android 15 (Target SDK 35)
- Verified that focus is cleared and the item moves/removes correctly without crashing.