### PR TITLE
Fix synchronization race condition

### DIFF
--- a/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
+++ b/app/src/main/java/org/qosp/notes/data/repo/NoteRepositoryImpl.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import me.msoul.datastore.defaultOf
 import org.qosp.notes.data.dao.IdMappingDao
 import org.qosp.notes.data.dao.NoteDao
@@ -46,6 +48,7 @@ class NoteRepositoryImpl(
 ) : NoteRepository {
 
     private val tag = NoteRepositoryImpl::class.java.simpleName
+    private val syncMutex = Mutex()
 
     private suspend fun cleanMappingsForLocalNotes(vararg notes: Note) {
         val n = notes.filter { it.isLocalOnly }
@@ -75,34 +78,40 @@ class NoteRepositoryImpl(
             }
         }
 
-        val syncMethod =
-            if (idMappingDao.getCountByCloudService(syncProvider.type) == 0)
-                SyncMethod.TITLE else SyncMethod.MAPPING
-        try {
-            // Get all local notes (excluding local-only ones)
-            val localNotes = getAll().first().filterNot { it.isLocalOnly || it.isDeleted }
+        return syncMutex.withLock {
+            val syncMethod =
+                if (idMappingDao.getCountByCloudService(syncProvider.type) == 0)
+                    SyncMethod.TITLE else SyncMethod.MAPPING
+            try {
+                // Get all local notes (excluding local-only ones)
+                val localNotes = getAll().first().filterNot { it.isLocalOnly || it.isDeleted }
 
-            // Get all remote notes and convert to metadata
-            val allRemoteNotes = syncProvider.getAll() ?: return GenericError("Failed to fetch remote notes")
-            Log.d(
-                tag, "syncNotes: Syncing by $syncMethod. " +
-                    "Found ${allRemoteNotes.size} remote notes, and ${localNotes.size} local notes"
-            )
+                // Get all remote notes and convert to metadata
+                val allRemoteNotes =
+                    syncProvider.getAll() ?: return@withLock GenericError("Failed to fetch remote notes")
+                Log.d(
+                    tag, "syncNotes: Syncing by $syncMethod. " +
+                        "Found ${allRemoteNotes.size} remote notes, and ${localNotes.size} local notes"
+                )
 
-            // Use SynchronizeNotes to determine what updates are needed
-            val syncResult =
-                synchronizeNotes(localNotes, allRemoteNotes, service = syncProvider.type, syncMethod)
-            Log.d(tag, "sync updates: ${syncResult.localUpdates.size} local, ${syncResult.remoteUpdates.size} remote")
+                // Use SynchronizeNotes to determine what updates are needed
+                val syncResult =
+                    synchronizeNotes(localNotes, allRemoteNotes, service = syncProvider.type, syncMethod)
+                Log.d(
+                    tag, "sync updates: ${syncResult.localUpdates.size} local, " +
+                        "${syncResult.remoteUpdates.size} remote"
+                )
 
-            if (syncMethod == SyncMethod.TITLE) applyMappingChanges(syncResult, syncProvider) // Initial import
-            applyLocalUpdates(syncResult.localUpdates, syncProvider)
-            applyRemoteUpdates(syncResult.remoteUpdates)
-            Log.i(tag, "syncNotes: Synchronization completed successfully")
-        } catch (e: Exception) {
-            Log.e(tag, "syncNotes: Synchronization failed: ${e.message}", e)
-            return GenericError(e.message ?: "Unknown error")
+                if (syncMethod == SyncMethod.TITLE) applyMappingChanges(syncResult, syncProvider) // Initial import
+                applyLocalUpdates(syncResult.localUpdates, syncProvider)
+                applyRemoteUpdates(syncResult.remoteUpdates)
+                Log.i(tag, "syncNotes: Synchronization completed successfully")
+            } catch (e: Exception) {
+                Log.e(tag, "syncNotes: Synchronization failed: ${e.message}", e)
+                return@withLock GenericError(e.message ?: "Unknown error")
+            }
+            Success
         }
-        return Success
     }
 
     private suspend fun applyLocalUpdates(localUpdates: List<NoteAction>, syncProvider: ISyncBackend) {


### PR DESCRIPTION
## Description
On a clean install, SyncWorker and ActivityViewModel.syncAsync() can run concurrently, both importing all remote notes and causing local duplicates:

    08-26 09:38:13.310 18011 D st2: syncNotes: Starting synchronization
    08-26 09:38:14.112 18009 D st2: syncNotes: Starting synchronization
    08-26 09:38:14.265 18008 D st2: syncNotes: Syncing by TITLE. Found 24 remote notes, and 1 local notes
    08-26 09:38:14.265 18008 D f34: SynchronizeNotes: Starting synchronization with method: TITLE
    08-26 09:38:14.265 18008 D f34: New Remote note: ...
    ...
    08-26 09:38:14.866 18009 D st2: syncNotes: Syncing by TITLE. Found 24 remote notes, and 1 local notes
    08-26 09:38:14.866 18009 D f34: SynchronizeNotes: Starting synchronization with method: TITLE
    08-26 09:38:14.866 18009 D f34: New Remote note: ...
    ...
    08-26 09:38:40.833 18008 D st2: syncNotes: Syncing by MAPPING. Found 26 remote notes, and 49 local notes

Fix by guarding syncNotes() with a mutex.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Cleanup
- [ ] Translation / Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project (we use `.editorconfig`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
